### PR TITLE
Fix for Users can have multiple concurrent sessions

### DIFF
--- a/dndserver/handlers/login.py
+++ b/dndserver/handlers/login.py
@@ -59,3 +59,8 @@ def process_login(ctx, msg):
     sessions[ctx.transport]["user"] = user
 
     return res
+
+def get_username_from_request(raw_request: bytes) -> str:
+    req = SC2S_ACCOUNT_LOGIN_REQ()
+    req.ParseFromString(raw_request)
+    return req.loginId


### PR DESCRIPTION
As requested: check if a session already exists, delete it, and disconnect the transport attached to it