### PR TITLE
bugfix using signed short instead unsigned short in unpack

### DIFF
--- a/dndserver/utils.py
+++ b/dndserver/utils.py
@@ -11,7 +11,7 @@ def make_header(msg: bytes):
     """Create a D&D packet header."""
     # header: <packet length: short> 00 00 <packet id: short> 00 00
     packet_type = type(msg).__name__.replace("SS2C", "S2C").replace("SC2S", "C2S")
-    return struct.pack("<hxxhxx", len(msg.SerializeToString()) + 8, pc.PacketCommand.Value(packet_type))
+    return struct.pack("<HxxHxx", len(msg.SerializeToString()) + 8, pc.PacketCommand.Value(packet_type))
 
 
 def get_user_by_nickname(nickname: str):


### PR DESCRIPTION
One of the messages for the merchant is 57656 bytes long the signed value limited is 32767 by changing to unsigned short it is increased to 65535.