### PR TITLE
Fix Concurrent Session Bug

### DIFF
--- a/dndserver/handlers/login.py
+++ b/dndserver/handlers/login.py
@@ -55,6 +55,17 @@ def process_login(ctx, msg):
     info = SLOGIN_ACCOUNT_INFO(AccountID=str(account.id))
     res.AccountInfo.CopyFrom(info)
 
+    kick_concurrent_user(account)
+
     sessions[ctx.transport].account = account
 
     return res
+
+
+def kick_concurrent_user(newly_connected_account):
+    """Searches for already connected account and kicks if a match is found."""
+    for transport, user in sessions.items():
+        # case where a duplicate account is found
+        if user.account == newly_connected_account:
+            transport.loseConnection()
+            break


### PR DESCRIPTION
# Notes
Short PR addressing [this task](https://github.com/users/Snaacky/projects/4?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=26413873).

* Added function to check `sessions` dict for an already connected `user.account` . If a match is found, then the connection is closed through `transport.loseConnection()`  (note that `GameProtocol.connectionLost()` will remove the entry from `sessions` on this call)
* Ran black to match formatting standards 

# Testing
* No 2 concurrent sessions are allowed. The old connection will be kicked and the new connection can successfully log in 