### PR TITLE
Corrected naming of perk

### DIFF
--- a/dndserver/data/perks.py
+++ b/dndserver/data/perks.py
@@ -71,7 +71,7 @@ rogue = [
     "DesignDataPerk:Id_Perk_Creep",
     "DesignDataPerk:Id_Perk_DaggerExpert",
     "DesignDataPerk:Id_Perk_HiddenPocket",
-    "DesignDataPerk:Id_Perk_LockpickSet",
+    "DesignDataPerk:Id_Perk_LockpickingMastery",
     "DesignDataPerk:Id_Perk_Pickpocket",
     "DesignDataPerk:Id_Perk_PoisonedWeapon",
     "DesignDataPerk:Id_Perk_Stealth",
@@ -107,7 +107,7 @@ perks = {
 # Other items. Not used at the moment.
 # DesignDataPerk:Id_Perk_Chase
 # DesignDataPerk:Id_Perk_DaggerMastery
-# DesignDataPerk:Id_Perk_LockpickingMastery
+# DesignDataPerk:Id_Perk_LockpickSet
 # DesignDataPerk:Id_Perk_Backstab
 # DesignDataPerk:Id_Perk_TwoHandedWeaponExpert
 # DesignDataPerk:Id_Perk_Malice

--- a/dndserver/data/perks.py
+++ b/dndserver/data/perks.py
@@ -56,11 +56,11 @@ ranger = [
     "DesignDataPerk:Id_Perk_EnhancedHearing",
     "DesignDataPerk:Id_Perk_Kinesthesia",
     "DesignDataPerk:Id_Perk_NimbleHands",
-    "DesignDataPerk:Id_Perk_RangedWeaponsExpert",
+    "DesignDataPerk:Id_Perk_RangedWeaponsMastery",
     "DesignDataPerk:Id_Perk_Sharpshooter",
     "DesignDataPerk:Id_Perk_SpearProficiency",
-    "DesignDataPerk:Id_Perk_Tracking",
-    "DesignDataPerk:Id_Perk_TrapExpert",
+    "DesignDataPerk:Id_Perk_Chase",
+    "DesignDataPerk:Id_Perk_TrapMastery",
     "DesignDataPerk:Id_Perk_CripplingShot",
     "DesignDataPerk:Id_Perk_QuickReload",
 ]
@@ -105,7 +105,7 @@ perks = {
 }
 
 # Other items. Not used at the moment.
-# DesignDataPerk:Id_Perk_Chase
+# DesignDataPerk:Id_Perk_Tracking
 # DesignDataPerk:Id_Perk_DaggerMastery
 # DesignDataPerk:Id_Perk_LockpickSet
 # DesignDataPerk:Id_Perk_Backstab
@@ -113,8 +113,8 @@ perks = {
 # DesignDataPerk:Id_Perk_Malice
 # DesignDataPerk:Id_Perk_Toughness
 # DesignDataPerk:Id_Perk_Smash
-# DesignDataPerk:Id_Perk_RangedWeaponsMastery
+# DesignDataPerk:Id_Perk_RangedWeaponsExpert
 # DesignDataPerk:Id_Perk_ShieldMastery
 # DesignDataPerk:Id_Perk_DefenseMastery
 # DesignDataPerk:Id_Perk_SurvivalistTongue
-# DesignDataPerk:Id_Perk_TrapMastery
+# DesignDataPerk:Id_Perk_TrapExpert


### PR DESCRIPTION
Swapping around LockpickSet and Lockpicking Mastery seemed to fix the problem of not seeing the perk ingame. 