### PR TITLE
Bugfix throwing exception when searching for a account in the party search

### DIFF
--- a/dndserver/utils.py
+++ b/dndserver/utils.py
@@ -13,7 +13,7 @@ def make_header(msg: bytes):
 
 def get_user(username: str = None, nickname: str = None, account_id: int = None):
     """Return a user object based on the account username, character nickname or account ID provided."""
-    if not all([username, nickname, account_id]):
+    if not any([username, nickname, account_id]):
         raise Exception("Did not pass username, nickname, or account_id, need at least one")
 
     for transport, session in sessions.items():


### PR DESCRIPTION
Bugfix checking for all inputs. This was crashing the server when searching for a account because of the exception. Changed it so it checks for any of the inputs