### PR TITLE
Added decline to party invite + bugfix double party invite

### DIFF
--- a/dndserver/handlers/party.py
+++ b/dndserver/handlers/party.py
@@ -43,6 +43,10 @@ def accept_invite(ctx, msg):
     # send a notification to the inviter that the invitee accepted
     send_accept_notification(ctx, req)
 
+    # check if the user accepted the invite
+    if req.inviteResult != pc.SUCCESS:
+        return SS2C_PARTY_INVITE_ANSWER_RES(result=pc.SUCCESS)
+
     # delete empty party if the user joining the party was the only member
     if len(sessions[ctx.transport].party.players) == 1:
         del parties[sessions[ctx.transport].party.id - 1]
@@ -53,6 +57,7 @@ def accept_invite(ctx, msg):
     # prevent invitee from joining the party if already member
     if any(sessions[ctx.transport].account.id == player.account.id for player in party.players):
         return SS2C_PARTY_INVITE_ANSWER_RESULT_NOT(inviteResult=pc.FAIL_PARTY_INVITE_ALREADY_PARTY)
+
     party.add_member(sessions[ctx.transport])
 
     # set the invitees party to the inviters party
@@ -88,7 +93,7 @@ def send_accept_notification(ctx, req):
             streamingModeNickName=sessions[ctx.transport].character.streaming_nickname,
             karmaRating=sessions[ctx.transport].character.karma_rating,
         ),
-        inviteResult=pc.SUCCESS,
+        inviteResult=req.inviteResult,
     )
     header = make_header(notify)
     transport.write(header + notify.SerializeToString())

--- a/dndserver/handlers/party.py
+++ b/dndserver/handlers/party.py
@@ -47,9 +47,9 @@ def accept_invite(ctx, msg):
     if any(sessions[ctx.transport].account.id == player.account.id for player in party.players):
         # do not process the response if we are already in the party we are trying to join
         return SS2C_PARTY_INVITE_ANSWER_RES(result=pc.SUCCESS)
-    else:
-        # send a notification with the response to the inviter
-        send_accept_notification(ctx, req)
+
+    # send a notification with the response to the inviter
+    send_accept_notification(ctx, req)
 
     # check if the user accepted the invite
     if req.inviteResult != pc.SUCCESS:

--- a/dndserver/handlers/party.py
+++ b/dndserver/handlers/party.py
@@ -61,7 +61,6 @@ def accept_invite(ctx, msg):
         del sessions[ctx.transport].party
 
     # add user to the inviters party object
-    party = get_party(account_id=int(req.returnAccountId))
     party.add_member(sessions[ctx.transport])
 
     # set the invitees party to the inviters party


### PR DESCRIPTION
Adds support to decline a party invite. Solves issue #200. Also solves a issue where we respond with the wrong response on the party invite request (this was causing a issue where it did not show the error popup). 

Also moved the last resort check before sending a response to all the clients. Now it just ignores the request straight away