### PR TITLE
Swapping gear in normal stash is now working

### DIFF
--- a/dndserver/handlers/inventory.py
+++ b/dndserver/handlers/inventory.py
@@ -350,8 +350,6 @@ def move_single_request(ctx, msg):
             db.query(Item)
             .filter_by(character_id=character.id)
             .filter_by(id=old.itemUniqueId)
-            .filter_by(slot_id=old.slotId)
-            .filter_by(inventory_id=old.inventoryId)
             .filter_by(item_id=old.itemId)
             .first()
         )


### PR DESCRIPTION
This should resolve the problem when you try to swap gear in the normal stash.

Previously, when you tried to swap items, one of the two was covered by the other or vice versa.

To test this problem just add an equipment to the character creation and try to swap them
Example:  `items.generate_item(ItemEnum.CLOTHPANTS, ItemType.ARMORS, Rarity.UNIQUE, 4, 6, 1)` inside `handlers/character.py`