### PR TITLE
Bugfix user staying in the gathering hall when a crash or alt+f4 closes the game

### DIFF
--- a/dndserver/handlers/gatheringhall.py
+++ b/dndserver/handlers/gatheringhall.py
@@ -58,6 +58,19 @@ def gathering_hall_equip(ctx, msg):
     return SS2C_GATHERING_HALL_TARGET_EQUIPPED_ITEM_RES(result=pc.SUCCESS, equippedItems=None, characterInfo=charinfo)
 
 
+def cleanup(ctx):
+    # Find the client's channel
+    current_channel = None
+    for ch in channels:
+        if ctx in channels[ch]["clients"]:
+            current_channel = ch
+            break
+
+    # remove the client from the channel if the client was in a channel
+    if current_channel:
+        channels[current_channel]["clients"].remove(ctx)
+
+
 def gathering_hall_channel_exit(ctx, msg):
     req = SC2S_GATHERING_HALL_CHANNEL_EXIT_REQ()
     req.ParseFromString(msg)

--- a/dndserver/protocol.py
+++ b/dndserver/protocol.py
@@ -41,6 +41,10 @@ class GameProtocol(Protocol):
     def connectionLost(self, reason):
         """Event for when a client disconnects from the server."""
         logger.debug(f"Lost connection to: {self.transport.client[0]}:{self.transport.client[1]}")
+
+        # cleanup anything left behind from the gathering hall
+        gatheringhall.cleanup(self)
+
         del sessions[self.transport]
 
     def dataReceived(self, data: bytes) -> None:


### PR DESCRIPTION
Added a cleanup for the gathering hall when we lose connection to the client. (the member count did not update because of this)