### PR TITLE
bugfix not sending party location notify when joining party

### DIFF
--- a/dndserver/handlers/party.py
+++ b/dndserver/handlers/party.py
@@ -73,6 +73,10 @@ def accept_invite(ctx, msg):
 
     send_party_info_notification(party)
 
+    # send the location of everyone to everyone
+    for user in party.players:
+        send_party_location_notification(party, user)
+
     return SS2C_PARTY_INVITE_ANSWER_RES(result=pc.SUCCESS)
 
 


### PR DESCRIPTION
## Briefly describe what changes this PR introduces
This fixes a issue where the location of the user is offline. This was partially fixed in #183 but it did not send the location when joining the party.

## Link to all issues that this PR solves
#132

## Relevant pictures/videos of the PR (optional)
https://github.com/Snaacky/dndserver/assets/9889898/5e66730d-35d4-42eb-98c4-c0fc61186daf

## Checklist
- [ ] This change introduces new dependencies and I have included updated `pyproject.toml` and `poetry.lock` files. 
- [ ] This change requires database migrations and I have included an alembic migration.