### PR TITLE
Service Policy Notification Partial Implementation

### DIFF
--- a/dndserver/handlers/login.py
+++ b/dndserver/handlers/login.py
@@ -7,7 +7,7 @@ from dndserver.database import db
 from dndserver.models import Account
 from dndserver.persistent import sessions
 from dndserver.protos.Account import SC2S_ACCOUNT_LOGIN_REQ, SLOGIN_ACCOUNT_INFO, SS2C_ACCOUNT_LOGIN_RES
-
+from dndserver.protos.Common import SS2C_SERVICE_POLICY_NOT, FSERVICE_POLICY
 
 def process_login(ctx, msg):
     """Occurs when the user attempts to login to the game server."""
@@ -59,7 +59,25 @@ def process_login(ctx, msg):
 
     sessions[ctx.transport].account = account
 
+    service_policy_notification(ctx)
+
     return res
+
+def service_policy_notification(ctx):
+
+    # Fix for Ante (High-Roller Entrance Fee)
+    # Policy Type '7' referes to High-Roller
+    # There's a lot more policy types, all with values, still unknown what each type does.
+    # and therefore will not implement the rest yet.
+
+    policy = FSERVICE_POLICY(
+        policyType = 7,
+        policyValue = 100
+    ),
+    FSERVICE_POLICY ()
+
+    notify = SS2C_SERVICE_POLICY_NOT(policyList=policy)
+    ctx.reply(notify)
 
 
 def kick_concurrent_user(newly_connected_account):


### PR DESCRIPTION
Implements the Service Policy Type 7, which is the entrance fee to high-roller dungeons. Service Policy NOT. is sent upon login, therefore I've called it at the end of the login process function.