### PR TITLE
Added support for going offline when in a party

### DIFF
--- a/dndserver/protocol.py
+++ b/dndserver/protocol.py
@@ -42,8 +42,9 @@ class GameProtocol(Protocol):
         """Event for when a client disconnects from the server."""
         logger.debug(f"Lost connection to: {self.transport.client[0]}:{self.transport.client[1]}")
 
-        # cleanup anything left behind from the gathering hall
+        # cleanup anything left behind from the gathering hall and the party
         gatheringhall.cleanup(self)
+        party.cleanup(self)
 
         del sessions[self.transport]
 


### PR DESCRIPTION
## Briefly describe what changes this PR introduces
Adds support for going offline after closing the game, crashing or alt-f4. Updates all the members in the party

## Link to all issues that this PR solves
* #193

## Relevant pictures/videos of the PR (optional)
![image](https://github.com/Snaacky/dndserver/assets/9889898/cd5bdfcf-c622-4a05-9d16-7fb2bdfb64cd)

![image](https://github.com/Snaacky/dndserver/assets/9889898/38d600c8-d1ce-4edc-a921-7948b079923f)

## Checklist
- [ ] This change introduces new dependencies and I have included updated `pyproject.toml` and `poetry.lock` files. 
- [ ] This change requires database migrations and I have included an alembic migration.