### PR TITLE
Python type hinting for all parameters and returns

### DIFF
--- a/dndserver/console.py
+++ b/dndserver/console.py
@@ -7,7 +7,7 @@ from dndserver.handlers.friends import count_friends
 from loguru import logger
 
 
-def enum(type, filter=None):
+def enum(type, filter=None) -> None:
     keys = []
     if type == "rarity":
         for key in Rarity:
@@ -21,16 +21,16 @@ def enum(type, filter=None):
                 keys.append(key.name)
             elif not filter:
                 keys.append(key.name)
-    logger.info(', '.join(keys))
+    logger.info(", ".join(keys))
 
 
-def help():
+def help() -> None:
     logger.info("List of available commands:")
     for _, info in commands.items():
         logger.info(info["help"])
 
 
-def give_item(user, item_name, item_type, rarity=Rarity.NONE, amount=1):
+def give_item(user, item_name, item_type, rarity=Rarity.NONE, amount=1) -> None:
     _, userAccount = get_user(nickname=user)
     if not userAccount:
         logger.debug("User is not online")
@@ -48,21 +48,21 @@ def give_item(user, item_name, item_type, rarity=Rarity.NONE, amount=1):
     it.save()
 
 
-def list(location=None):
+def list(location=None) -> None:
     try:
         _, in_lobby, in_dungeon = count_friends()
     except Exception:
         logger.info("No users currently online.")
         return
-    if location == 'lobby':
+    if location == "lobby":
         logger.info(f"Currently in lobby : {in_lobby}")
-    elif location == 'dungeon':
+    elif location == "dungeon":
         logger.info(f"Currently in dungeon : {in_dungeon}")
     else:
         logger.info(f"Currently online : {in_lobby + in_dungeon}")
 
 
-def exit():
+def exit() -> None:
     sys.exit(0)
 
 
@@ -76,7 +76,7 @@ commands = {
 }
 
 
-def console():
+def console() -> None:
     line = None
     while True:
         try:

--- a/dndserver/handlers/character.py
+++ b/dndserver/handlers/character.py
@@ -55,7 +55,7 @@ from dndserver.protos.Item import (
 from dndserver.protos.Lobby import SS2C_LOBBY_CHARACTER_INFO_RES
 
 
-def item_to_proto_item(item, attributes, for_character=True) -> pItem.SItem:
+def item_to_proto_item(item: Item, attributes: List[ItemAttribute], for_character: bool = True) -> pItem.SItem:
     """Helper function to create a proto item from a database item and attributes"""
     ret = pItem.SItem()
 
@@ -80,7 +80,7 @@ def item_to_proto_item(item, attributes, for_character=True) -> pItem.SItem:
     return ret
 
 
-def list_characters(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_LIST_RES:
+def list_characters(ctx, msg: bytes) -> SS2C_ACCOUNT_CHARACTER_LIST_RES:
     """Occurs when the user loads in to the character selection screen."""
     req = SC2S_ACCOUNT_CHARACTER_LIST_REQ()
     req.ParseFromString(msg)
@@ -112,7 +112,7 @@ def list_characters(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_LIST_RES:
     return res
 
 
-def create_character(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_CREATE_RES:
+def create_character(ctx, msg: bytes) -> SS2C_ACCOUNT_CHARACTER_CREATE_RES:
     """Occurs when the user attempts to create a new character."""
     req = SC2S_ACCOUNT_CHARACTER_CREATE_REQ()
     req.ParseFromString(msg)
@@ -181,7 +181,7 @@ def create_character(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_CREATE_RES:
     return res
 
 
-def delete_character(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_DELETE_RES:
+def delete_character(ctx, msg: bytes) -> SS2C_ACCOUNT_CHARACTER_DELETE_RES:
     """Occurs when the user attempts to delete a character."""
     req = SC2S_ACCOUNT_CHARACTER_DELETE_REQ()
     req.ParseFromString(msg)
@@ -218,7 +218,7 @@ def delete_character(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_DELETE_RES:
     return res
 
 
-def customise_character_info(ctx, msg) -> SS2C_CUSTOMIZE_CHARACTER_INFO_RES:
+def customise_character_info(ctx, msg: bytes) -> SS2C_CUSTOMIZE_CHARACTER_INFO_RES:
     custom = SCUSTOMIZE_CHARACTER(customizeCharacterId="1", isEquip=1, isNew=1)
     res = SS2C_CUSTOMIZE_CHARACTER_INFO_RES()
     res.loopFlag = 0
@@ -226,7 +226,7 @@ def customise_character_info(ctx, msg) -> SS2C_CUSTOMIZE_CHARACTER_INFO_RES:
     return res
 
 
-def character_info(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def character_info(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user loads into the lobby/tavern."""
     character = sessions[ctx.transport].character
 
@@ -254,7 +254,7 @@ def character_info(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     return res
 
 
-def get_experience(ctx, msg) -> SS2C_CLASS_LEVEL_INFO_RES:
+def get_experience(ctx, msg: bytes) -> SS2C_CLASS_LEVEL_INFO_RES:
     """Occurs when the user loads into the lobby."""
     character = sessions[ctx.transport].character
     res = SS2C_CLASS_LEVEL_INFO_RES()
@@ -269,7 +269,7 @@ def get_experience(ctx, msg) -> SS2C_CLASS_LEVEL_INFO_RES:
     return res
 
 
-def list_perks(ctx, msg) -> SS2C_CLASS_PERK_LIST_RES:
+def list_perks(ctx, msg: bytes) -> SS2C_CLASS_PERK_LIST_RES:
     """Occurs when user selects the class menu."""
     character = sessions[ctx.transport].character
     selected_perks = [character.perk0, character.perk1, character.perk2, character.perk3]
@@ -287,7 +287,7 @@ def list_perks(ctx, msg) -> SS2C_CLASS_PERK_LIST_RES:
     return res
 
 
-def list_skills(ctx, msg) -> SS2C_CLASS_SKILL_LIST_RES:
+def list_skills(ctx, msg: bytes) -> SS2C_CLASS_SKILL_LIST_RES:
     """Occurs when user selects the class menu."""
     character = sessions[ctx.transport].character
     selected_skills = [character.skill0, character.skill1]
@@ -305,7 +305,7 @@ def list_skills(ctx, msg) -> SS2C_CLASS_SKILL_LIST_RES:
     return res
 
 
-def list_spells(ctx, msg) -> SS2C_CLASS_SPELL_LIST_RES:
+def list_spells(ctx, msg: bytes) -> SS2C_CLASS_SPELL_LIST_RES:
     """Occurs when the user loads opens the class menu."""
     req = SC2S_CLASS_SPELL_LIST_REQ()
     req.ParseFromString(msg)
@@ -338,7 +338,7 @@ def list_spells(ctx, msg) -> SS2C_CLASS_SPELL_LIST_RES:
     return res
 
 
-def get_spells(character_id) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
+def get_spells(character_id: int) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
     """Helper function to create the spell slot response"""
     res = SS2C_CLASS_SPELL_SLOT_MOVE_RES()
     res.result = pc.SUCCESS
@@ -354,7 +354,7 @@ def get_spells(character_id) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
     return res
 
 
-def update_spell_sequence(update_from, character_id) -> None:
+def update_spell_sequence(update_from: int, character_id: int) -> None:
     """Helper function to update the sequences above the update_from"""
     spells = (
         db.query(Spell)
@@ -367,7 +367,7 @@ def update_spell_sequence(update_from, character_id) -> None:
         spell.sequence_id = update_from + index
 
 
-def move_spell(ctx, msg) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
+def move_spell(ctx, msg: bytes) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
     """Occurs when the user moves a spell."""
     req = SC2S_CLASS_SPELL_SLOT_MOVE_REQ()
     req.ParseFromString(msg)
@@ -441,7 +441,7 @@ def move_spell(ctx, msg) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
     return get_spells(char.id)
 
 
-def get_perks_and_skills(ctx, msg) -> SS2C_CLASS_EQUIP_INFO_RES:
+def get_perks_and_skills(ctx, msg: bytes) -> SS2C_CLASS_EQUIP_INFO_RES:
     """Occurs when the user loads in the game or loads into the class menu."""
     character = sessions[ctx.transport].character
     res = SS2C_CLASS_EQUIP_INFO_RES()
@@ -475,7 +475,7 @@ def get_perks_and_skills(ctx, msg) -> SS2C_CLASS_EQUIP_INFO_RES:
     return res
 
 
-def move_perks_and_skills(ctx, msg) -> SS2C_CLASS_ITEM_MOVE_RES:
+def move_perks_and_skills(ctx, msg: bytes) -> SS2C_CLASS_ITEM_MOVE_RES:
     """Occurs when the user tries to move either a perk or a skill."""
     req = SC2S_CLASS_ITEM_MOVE_REQ()
     req.ParseFromString(msg)
@@ -514,7 +514,7 @@ def move_perks_and_skills(ctx, msg) -> SS2C_CLASS_ITEM_MOVE_RES:
     return SS2C_CLASS_ITEM_MOVE_RES(result=pc.SUCCESS, oldMove=req.oldMove, newMove=req.newMove)
 
 
-def create_items_per_class(char_class) -> List[pItem.SItem]:
+def create_items_per_class(char_class: CharacterClass) -> List[pItem.SItem]:
     match char_class:
         case CharacterClass.BARBARIAN:
             return [
@@ -654,7 +654,7 @@ def create_items_per_class(char_class) -> List[pItem.SItem]:
     return []
 
 
-def emote_info(ctx, msg) -> SS2C_CUSTOMIZE_EMOTE_INFO_RES:
+def emote_info(ctx, msg: bytes) -> SS2C_CUSTOMIZE_EMOTE_INFO_RES:
     custom = SEMOTE(emoteId="1", equipSlotIndex=1, isNew=1)
     res = SS2C_CUSTOMIZE_EMOTE_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE
@@ -662,7 +662,7 @@ def emote_info(ctx, msg) -> SS2C_CUSTOMIZE_EMOTE_INFO_RES:
     return res
 
 
-def lobby_emote_info(ctx, msg) -> SS2C_CUSTOMIZE_LOBBY_EMOTE_INFO_RES:
+def lobby_emote_info(ctx, msg: bytes) -> SS2C_CUSTOMIZE_LOBBY_EMOTE_INFO_RES:
     custom = SCUSTOMIZE_LOBBY_EMOTE(lobbyEmoteId="1", equipSlotIndex=1, isNew=1)
     res = SS2C_CUSTOMIZE_LOBBY_EMOTE_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE
@@ -670,7 +670,7 @@ def lobby_emote_info(ctx, msg) -> SS2C_CUSTOMIZE_LOBBY_EMOTE_INFO_RES:
     return res
 
 
-def item_info(ctx, msg) -> SS2C_CUSTOMIZE_ITEM_INFO_RES:
+def item_info(ctx, msg: bytes) -> SS2C_CUSTOMIZE_ITEM_INFO_RES:
     custom = SCUSTOMIZE_ITEM(customizeItemId="1", isEquip=1, isNew=1)
     res = SS2C_CUSTOMIZE_ITEM_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE
@@ -678,7 +678,7 @@ def item_info(ctx, msg) -> SS2C_CUSTOMIZE_ITEM_INFO_RES:
     return res
 
 
-def action_info(ctx, msg) -> SS2C_CUSTOMIZE_ACTION_INFO_RES:
+def action_info(ctx, msg: bytes) -> SS2C_CUSTOMIZE_ACTION_INFO_RES:
     custom = SCUSTOMIZE_ACTION(customizeActionId="1", isEquip=1, isNew=1)
     res = SS2C_CUSTOMIZE_ACTION_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE

--- a/dndserver/handlers/character.py
+++ b/dndserver/handlers/character.py
@@ -1,4 +1,5 @@
 import random
+from typing import List
 
 from dndserver.data import perks as pk
 from dndserver.data import skills as sk
@@ -54,7 +55,7 @@ from dndserver.protos.Item import (
 from dndserver.protos.Lobby import SS2C_LOBBY_CHARACTER_INFO_RES
 
 
-def item_to_proto_item(item, attributes, for_character=True):
+def item_to_proto_item(item, attributes, for_character=True) -> pItem.SItem:
     """Helper function to create a proto item from a database item and attributes"""
     ret = pItem.SItem()
 
@@ -79,7 +80,7 @@ def item_to_proto_item(item, attributes, for_character=True):
     return ret
 
 
-def list_characters(ctx, msg):
+def list_characters(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_LIST_RES:
     """Occurs when the user loads in to the character selection screen."""
     req = SC2S_ACCOUNT_CHARACTER_LIST_REQ()
     req.ParseFromString(msg)
@@ -111,7 +112,7 @@ def list_characters(ctx, msg):
     return res
 
 
-def create_character(ctx, msg):
+def create_character(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_CREATE_RES:
     """Occurs when the user attempts to create a new character."""
     req = SC2S_ACCOUNT_CHARACTER_CREATE_REQ()
     req.ParseFromString(msg)
@@ -180,7 +181,7 @@ def create_character(ctx, msg):
     return res
 
 
-def delete_character(ctx, msg):
+def delete_character(ctx, msg) -> SS2C_ACCOUNT_CHARACTER_DELETE_RES:
     """Occurs when the user attempts to delete a character."""
     req = SC2S_ACCOUNT_CHARACTER_DELETE_REQ()
     req.ParseFromString(msg)
@@ -217,7 +218,7 @@ def delete_character(ctx, msg):
     return res
 
 
-def customise_character_info(ctx, msg):
+def customise_character_info(ctx, msg) -> SS2C_CUSTOMIZE_CHARACTER_INFO_RES:
     custom = SCUSTOMIZE_CHARACTER(customizeCharacterId="1", isEquip=1, isNew=1)
     res = SS2C_CUSTOMIZE_CHARACTER_INFO_RES()
     res.loopFlag = 0
@@ -225,7 +226,7 @@ def customise_character_info(ctx, msg):
     return res
 
 
-def character_info(ctx, msg):
+def character_info(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user loads into the lobby/tavern."""
     character = sessions[ctx.transport].character
 
@@ -253,7 +254,7 @@ def character_info(ctx, msg):
     return res
 
 
-def get_experience(ctx, msg):
+def get_experience(ctx, msg) -> SS2C_CLASS_LEVEL_INFO_RES:
     """Occurs when the user loads into the lobby."""
     character = sessions[ctx.transport].character
     res = SS2C_CLASS_LEVEL_INFO_RES()
@@ -268,7 +269,7 @@ def get_experience(ctx, msg):
     return res
 
 
-def list_perks(ctx, msg):
+def list_perks(ctx, msg) -> SS2C_CLASS_PERK_LIST_RES:
     """Occurs when user selects the class menu."""
     character = sessions[ctx.transport].character
     selected_perks = [character.perk0, character.perk1, character.perk2, character.perk3]
@@ -286,7 +287,7 @@ def list_perks(ctx, msg):
     return res
 
 
-def list_skills(ctx, msg):
+def list_skills(ctx, msg) -> SS2C_CLASS_SKILL_LIST_RES:
     """Occurs when user selects the class menu."""
     character = sessions[ctx.transport].character
     selected_skills = [character.skill0, character.skill1]
@@ -304,7 +305,7 @@ def list_skills(ctx, msg):
     return res
 
 
-def list_spells(ctx, msg):
+def list_spells(ctx, msg) -> SS2C_CLASS_SPELL_LIST_RES:
     """Occurs when the user loads opens the class menu."""
     req = SC2S_CLASS_SPELL_LIST_REQ()
     req.ParseFromString(msg)
@@ -337,7 +338,7 @@ def list_spells(ctx, msg):
     return res
 
 
-def get_spells(character_id):
+def get_spells(character_id) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
     """Helper function to create the spell slot response"""
     res = SS2C_CLASS_SPELL_SLOT_MOVE_RES()
     res.result = pc.SUCCESS
@@ -353,7 +354,7 @@ def get_spells(character_id):
     return res
 
 
-def update_spell_sequence(update_from, character_id):
+def update_spell_sequence(update_from, character_id) -> None:
     """Helper function to update the sequences above the update_from"""
     spells = (
         db.query(Spell)
@@ -366,7 +367,7 @@ def update_spell_sequence(update_from, character_id):
         spell.sequence_id = update_from + index
 
 
-def move_spell(ctx, msg):
+def move_spell(ctx, msg) -> SS2C_CLASS_SPELL_SLOT_MOVE_RES:
     """Occurs when the user moves a spell."""
     req = SC2S_CLASS_SPELL_SLOT_MOVE_REQ()
     req.ParseFromString(msg)
@@ -440,7 +441,7 @@ def move_spell(ctx, msg):
     return get_spells(char.id)
 
 
-def get_perks_and_skills(ctx, msg):
+def get_perks_and_skills(ctx, msg) -> SS2C_CLASS_EQUIP_INFO_RES:
     """Occurs when the user loads in the game or loads into the class menu."""
     character = sessions[ctx.transport].character
     res = SS2C_CLASS_EQUIP_INFO_RES()
@@ -474,7 +475,7 @@ def get_perks_and_skills(ctx, msg):
     return res
 
 
-def move_perks_and_skills(ctx, msg):
+def move_perks_and_skills(ctx, msg) -> SS2C_CLASS_ITEM_MOVE_RES:
     """Occurs when the user tries to move either a perk or a skill."""
     req = SC2S_CLASS_ITEM_MOVE_REQ()
     req.ParseFromString(msg)
@@ -513,7 +514,7 @@ def move_perks_and_skills(ctx, msg):
     return SS2C_CLASS_ITEM_MOVE_RES(result=pc.SUCCESS, oldMove=req.oldMove, newMove=req.newMove)
 
 
-def create_items_per_class(char_class):
+def create_items_per_class(char_class) -> List[pItem.SItem]:
     match char_class:
         case CharacterClass.BARBARIAN:
             return [
@@ -653,7 +654,7 @@ def create_items_per_class(char_class):
     return []
 
 
-def emote_info(ctx, msg):
+def emote_info(ctx, msg) -> SS2C_CUSTOMIZE_EMOTE_INFO_RES:
     custom = SEMOTE(emoteId="1", equipSlotIndex=1, isNew=1)
     res = SS2C_CUSTOMIZE_EMOTE_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE
@@ -661,7 +662,7 @@ def emote_info(ctx, msg):
     return res
 
 
-def lobby_emote_info(ctx, msg):
+def lobby_emote_info(ctx, msg) -> SS2C_CUSTOMIZE_LOBBY_EMOTE_INFO_RES:
     custom = SCUSTOMIZE_LOBBY_EMOTE(lobbyEmoteId="1", equipSlotIndex=1, isNew=1)
     res = SS2C_CUSTOMIZE_LOBBY_EMOTE_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE
@@ -669,7 +670,7 @@ def lobby_emote_info(ctx, msg):
     return res
 
 
-def item_info(ctx, msg):
+def item_info(ctx, msg) -> SS2C_CUSTOMIZE_ITEM_INFO_RES:
     custom = SCUSTOMIZE_ITEM(customizeItemId="1", isEquip=1, isNew=1)
     res = SS2C_CUSTOMIZE_ITEM_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE
@@ -677,7 +678,7 @@ def item_info(ctx, msg):
     return res
 
 
-def action_info(ctx, msg):
+def action_info(ctx, msg) -> SS2C_CUSTOMIZE_ACTION_INFO_RES:
     custom = SCUSTOMIZE_ACTION(customizeActionId="1", isEquip=1, isNew=1)
     res = SS2C_CUSTOMIZE_ACTION_INFO_RES()
     res.loopFlag = Define_Message.LoopFlag.NONE

--- a/dndserver/handlers/friends.py
+++ b/dndserver/handlers/friends.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from dndserver.config import config
 from dndserver.database import db
 from dndserver.enums.classes import CharacterClass, Gender
@@ -20,7 +22,7 @@ from dndserver.utils import get_user
 from dndserver.handlers.party import get_party
 
 
-def count_friends():
+def count_friends() -> Tuple[SCHARACTER_FRIEND_INFO, int, int]:
     # counters for the lobby and the dungeon
     in_lobby = 0
     in_dungeon = 0
@@ -66,7 +68,7 @@ def count_friends():
     return friend_info, in_lobby, in_dungeon
 
 
-def list_friends(ctx, msg):
+def list_friends(ctx, msg) -> SS2C_FRIEND_LIST_ALL_RES:
     # send the loop start
     ctx.reply(SS2C_FRIEND_LIST_ALL_RES(loopFlag=Define_Message.LoopFlag.BEGIN))
 
@@ -87,7 +89,7 @@ def list_friends(ctx, msg):
     )
 
 
-def find_user(ctx, msg):
+def find_user(ctx, msg) -> SS2C_FRIEND_FIND_RES:
     # message SC2S_FRIEND_FIND_REQ {
     #   .DC.Packet.SACCOUNT_NICKNAME nickName = 1;
     # }
@@ -134,7 +136,7 @@ def find_user(ctx, msg):
     return res
 
 
-def block_user(ctx, msg):
+def block_user(ctx, msg) -> SS2C_BLOCK_CHARACTER_RES:
     """Occurs when a character blocks another character."""
     req = SC2S_BLOCK_CHARACTER_REQ()
     req.ParseFromString(msg)
@@ -179,7 +181,7 @@ def block_user(ctx, msg):
     return res
 
 
-def unblock_user(ctx, msg):
+def unblock_user(ctx, msg) -> SS2C_UNBLOCK_CHARACTER_RES:
     """Occurs when a character unblocks another character."""
     # message SC2S_UNBLOCK_CHARACTER_REQ {
     #   string targetAccountId = 1;
@@ -203,7 +205,7 @@ def unblock_user(ctx, msg):
     return SS2C_UNBLOCK_CHARACTER_RES(result=pc.SUCCESS, targetCharacterId=req.targetCharacterId)
 
 
-def get_blocked_users(ctx, msg):
+def get_blocked_users(ctx, msg) -> SS2C_BLOCK_CHARACTER_LIST_RES:
     # message SC2S_BLOCK_CHARACTER_LIST_REQ {}
     req = SC2S_BLOCK_CHARACTER_LIST_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/friends.py
+++ b/dndserver/handlers/friends.py
@@ -68,7 +68,7 @@ def count_friends() -> Tuple[SCHARACTER_FRIEND_INFO, int, int]:
     return friend_info, in_lobby, in_dungeon
 
 
-def list_friends(ctx, msg) -> SS2C_FRIEND_LIST_ALL_RES:
+def list_friends(ctx, msg: bytes) -> SS2C_FRIEND_LIST_ALL_RES:
     # send the loop start
     ctx.reply(SS2C_FRIEND_LIST_ALL_RES(loopFlag=Define_Message.LoopFlag.BEGIN))
 
@@ -89,7 +89,7 @@ def list_friends(ctx, msg) -> SS2C_FRIEND_LIST_ALL_RES:
     )
 
 
-def find_user(ctx, msg) -> SS2C_FRIEND_FIND_RES:
+def find_user(ctx, msg: bytes) -> SS2C_FRIEND_FIND_RES:
     # message SC2S_FRIEND_FIND_REQ {
     #   .DC.Packet.SACCOUNT_NICKNAME nickName = 1;
     # }
@@ -136,7 +136,7 @@ def find_user(ctx, msg) -> SS2C_FRIEND_FIND_RES:
     return res
 
 
-def block_user(ctx, msg) -> SS2C_BLOCK_CHARACTER_RES:
+def block_user(ctx, msg: bytes) -> SS2C_BLOCK_CHARACTER_RES:
     """Occurs when a character blocks another character."""
     req = SC2S_BLOCK_CHARACTER_REQ()
     req.ParseFromString(msg)
@@ -181,7 +181,7 @@ def block_user(ctx, msg) -> SS2C_BLOCK_CHARACTER_RES:
     return res
 
 
-def unblock_user(ctx, msg) -> SS2C_UNBLOCK_CHARACTER_RES:
+def unblock_user(ctx, msg: bytes) -> SS2C_UNBLOCK_CHARACTER_RES:
     """Occurs when a character unblocks another character."""
     # message SC2S_UNBLOCK_CHARACTER_REQ {
     #   string targetAccountId = 1;
@@ -205,7 +205,7 @@ def unblock_user(ctx, msg) -> SS2C_UNBLOCK_CHARACTER_RES:
     return SS2C_UNBLOCK_CHARACTER_RES(result=pc.SUCCESS, targetCharacterId=req.targetCharacterId)
 
 
-def get_blocked_users(ctx, msg) -> SS2C_BLOCK_CHARACTER_LIST_RES:
+def get_blocked_users(ctx, msg: bytes) -> SS2C_BLOCK_CHARACTER_LIST_RES:
     # message SC2S_BLOCK_CHARACTER_LIST_REQ {}
     req = SC2S_BLOCK_CHARACTER_LIST_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/gatheringhall.py
+++ b/dndserver/handlers/gatheringhall.py
@@ -19,12 +19,13 @@ from dndserver.protos.GatheringHall import (
     SS2C_GATHERING_HALL_TARGET_EQUIPPED_ITEM_RES,
 )
 
+
 channels = {}
 for i in range(1, 7):
     channels[f"channel{i}"] = {"index": i, "clients": []}
 
 
-def gathering_hall_channel_list(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_LIST_RES:
+def gathering_hall_channel_list(ctx, msg: bytes) -> SS2C_GATHERING_HALL_CHANNEL_LIST_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_LIST_REQ()
     req.ParseFromString(msg)
     res = SS2C_GATHERING_HALL_CHANNEL_LIST_RES()
@@ -40,14 +41,14 @@ def gathering_hall_channel_list(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_LIST_RE
     return res
 
 
-def gathering_hall_select_channel(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_SELECT_RES:
+def gathering_hall_select_channel(ctx, msg: bytes) -> SS2C_GATHERING_HALL_CHANNEL_SELECT_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_SELECT_REQ()
     req.ParseFromString(msg)
     channels[f"channel{req.channelIndex}"]["clients"].append(ctx)
     return SS2C_GATHERING_HALL_CHANNEL_SELECT_RES(result=pc.SUCCESS)
 
 
-def gathering_hall_equip(ctx, msg) -> SS2C_GATHERING_HALL_TARGET_EQUIPPED_ITEM_RES:
+def gathering_hall_equip(ctx, msg: bytes) -> SS2C_GATHERING_HALL_TARGET_EQUIPPED_ITEM_RES:
     req = SC2S_GATHERING_HALL_TARGET_EQUIPPED_ITEM_REQ()
     req.ParseFromString(msg)
     query = db.query(Character).filter_by(id=req.characterId).first()
@@ -71,7 +72,7 @@ def cleanup(ctx) -> None:
         channels[current_channel]["clients"].remove(ctx)
 
 
-def gathering_hall_channel_exit(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_EXIT_RES:
+def gathering_hall_channel_exit(ctx, msg: bytes) -> SS2C_GATHERING_HALL_CHANNEL_EXIT_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_EXIT_REQ()
     req.ParseFromString(msg)
 
@@ -93,7 +94,7 @@ def gathering_hall_channel_exit(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_EXIT_RE
     return res
 
 
-def broadcast_chat(ctx, msg) -> None:
+def broadcast_chat(ctx, msg: bytes) -> None:
     # Broadcast the message to other clients
     res = SS2C_GATHERING_HALL_CHANNEL_CHAT_RES(result=pc.SUCCESS, chats=msg)
 
@@ -111,7 +112,7 @@ def broadcast_chat(ctx, msg) -> None:
                 client.reply(res)
 
 
-def chat(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_CHAT_RES:
+def chat(ctx, msg: bytes) -> SS2C_GATHERING_HALL_CHANNEL_CHAT_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_CHAT_REQ()
     req.ParseFromString(msg)
 

--- a/dndserver/handlers/gatheringhall.py
+++ b/dndserver/handlers/gatheringhall.py
@@ -24,7 +24,7 @@ for i in range(1, 7):
     channels[f"channel{i}"] = {"index": i, "clients": []}
 
 
-def gathering_hall_channel_list(ctx, msg):
+def gathering_hall_channel_list(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_LIST_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_LIST_REQ()
     req.ParseFromString(msg)
     res = SS2C_GATHERING_HALL_CHANNEL_LIST_RES()
@@ -40,14 +40,14 @@ def gathering_hall_channel_list(ctx, msg):
     return res
 
 
-def gathering_hall_select_channel(ctx, msg):
+def gathering_hall_select_channel(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_SELECT_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_SELECT_REQ()
     req.ParseFromString(msg)
     channels[f"channel{req.channelIndex}"]["clients"].append(ctx)
     return SS2C_GATHERING_HALL_CHANNEL_SELECT_RES(result=pc.SUCCESS)
 
 
-def gathering_hall_equip(ctx, msg):
+def gathering_hall_equip(ctx, msg) -> SS2C_GATHERING_HALL_TARGET_EQUIPPED_ITEM_RES:
     req = SC2S_GATHERING_HALL_TARGET_EQUIPPED_ITEM_REQ()
     req.ParseFromString(msg)
     query = db.query(Character).filter_by(id=req.characterId).first()
@@ -58,7 +58,7 @@ def gathering_hall_equip(ctx, msg):
     return SS2C_GATHERING_HALL_TARGET_EQUIPPED_ITEM_RES(result=pc.SUCCESS, equippedItems=None, characterInfo=charinfo)
 
 
-def cleanup(ctx):
+def cleanup(ctx) -> None:
     # Find the client's channel
     current_channel = None
     for ch in channels:
@@ -71,7 +71,7 @@ def cleanup(ctx):
         channels[current_channel]["clients"].remove(ctx)
 
 
-def gathering_hall_channel_exit(ctx, msg):
+def gathering_hall_channel_exit(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_EXIT_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_EXIT_REQ()
     req.ParseFromString(msg)
 
@@ -93,7 +93,7 @@ def gathering_hall_channel_exit(ctx, msg):
     return res
 
 
-def broadcast_chat(ctx, msg):
+def broadcast_chat(ctx, msg) -> None:
     # Broadcast the message to other clients
     res = SS2C_GATHERING_HALL_CHANNEL_CHAT_RES(result=pc.SUCCESS, chats=msg)
 
@@ -111,7 +111,7 @@ def broadcast_chat(ctx, msg):
                 client.reply(res)
 
 
-def chat(ctx, msg):
+def chat(ctx, msg) -> SS2C_GATHERING_HALL_CHANNEL_CHAT_RES:
     req = SC2S_GATHERING_HALL_CHANNEL_CHAT_REQ()
     req.ParseFromString(msg)
 

--- a/dndserver/handlers/inventory.py
+++ b/dndserver/handlers/inventory.py
@@ -20,9 +20,13 @@ from dndserver.protos.Inventory import (
     SS2C_INVENTORY_SPLIT_MERGE_RES,
 )
 from dndserver.protos.Lobby import SS2C_LOBBY_CHARACTER_INFO_RES
+from dndserver.protos.Defines import Define_Item, Define_Equipment
+from dndserver.protos.Item import SItem
 
 
-def get_all_items(character_id, inventory_id=None, slot_id=None) -> List[Tuple[Item, List[ItemAttribute]]]:
+def get_all_items(
+    character_id: int, inventory_id: Define_Item.InventoryId = None, slot_id: Define_Equipment.SlotId = None
+) -> List[Tuple[Item, List[ItemAttribute]]]:
     """Helper function to get all items for a character id"""
     query = db.query(Item).filter_by(character_id=character_id).filter_by(index=0)
 
@@ -44,7 +48,7 @@ def get_all_items(character_id, inventory_id=None, slot_id=None) -> List[Tuple[I
     return ret
 
 
-def delete_item(character_id, item, is_query=False) -> bool:
+def delete_item(character_id: int, item: Item | SItem, is_query: bool = False) -> bool:
     """Helper function to remove a item from a character"""
     if is_query:
         query = item
@@ -66,7 +70,7 @@ def delete_item(character_id, item, is_query=False) -> bool:
     return True
 
 
-def add_item(item) -> None:
+def add_item(item: Tuple[Item, List[ItemAttribute]]) -> None:
     """Helper function to add a item to a character"""
     it, attributes = item
 
@@ -77,7 +81,7 @@ def add_item(item) -> None:
         attribute.save()
 
 
-def get_stack_limit(item) -> int:
+def get_stack_limit(item: str) -> int:
     """Helper function to the get the amount we can stack a item"""
     # TODO: this should be read from the item directly
     if "Id_Item_Bandage" in item or "Potion" in item or "Id_Item_ThrowingKnife" in item:
@@ -92,7 +96,7 @@ def get_stack_limit(item) -> int:
         return 0
 
 
-def get_inv_limit(item) -> int:
+def get_inv_limit(item: str) -> int:
     """Helper function to get the max inventory count for a item"""
     # TODO: get real values for limits
     if "Id_Item_GoldCoinPurse" in item:
@@ -105,7 +109,15 @@ def get_inv_limit(item) -> int:
         return 0
 
 
-def split_item(from_item, item_id, to_inventory, to_slot, quantity, character_id, from_is_persistent=True) -> int:
+def split_item(
+    from_item: Item,
+    item_id: str,
+    to_inventory: Define_Item.InventoryId,
+    to_slot: Define_Equipment.SlotId,
+    quantity: int,
+    character_id: int,
+    from_is_persistent: bool = True,
+) -> int:
     """Helper function to split a item and generate a new item at the provided location"""
     it = Item()
     it.character_id = character_id
@@ -152,7 +164,9 @@ def split_item(from_item, item_id, to_inventory, to_slot, quantity, character_id
     return it.id
 
 
-def merge_items(from_item, to_item, amount, character_id, from_is_persistent=True) -> bool:
+def merge_items(
+    from_item: Item, to_item: Item, amount: int, character_id: int, from_is_persistent: bool = True
+) -> bool:
     """Helper function to merge two items."""
     # Check how we can merge the two items
     if get_inv_limit(from_item.item_id) and get_inv_limit(to_item.item_id):
@@ -197,7 +211,7 @@ def merge_items(from_item, to_item, amount, character_id, from_is_persistent=Tru
     return True
 
 
-def merge_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def merge_request(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user drags an item on another in the merchant screen."""
     req = SC2S_INVENTORY_MERGE_REQ()
     req.ParseFromString(msg)
@@ -220,7 +234,7 @@ def merge_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     return HCharacter.character_info(ctx, bytearray())
 
 
-def split_move_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def split_move_request(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user wants to split an item in the merchant screen."""
     req = SC2S_INVENTORY_SPLIT_MOVE_REQ()
     req.ParseFromString(msg)
@@ -258,7 +272,7 @@ def split_move_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     return HCharacter.character_info(ctx, bytearray())
 
 
-def swap_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def swap_request(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user wants to swap two items in the merchant screen."""
     req = SC2S_INVENTORY_SWAP_REQ()
     req.ParseFromString(msg)
@@ -282,7 +296,7 @@ def swap_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     return HCharacter.character_info(ctx, bytearray())
 
 
-def split_merge_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def split_merge_request(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user wants to split and merge the result on another item in the merchant screen."""
     req = SC2S_INVENTORY_SPLIT_MERGE_REQ()
     req.ParseFromString(msg)
@@ -318,7 +332,7 @@ def split_merge_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     return HCharacter.character_info(ctx, bytearray())
 
 
-def move_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def move_request(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user moves an item at a merchant"""
     req = SC2S_INVENTORY_MOVE_REQ()
     req.ParseFromString(msg)
@@ -344,7 +358,7 @@ def move_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     return HCharacter.character_info(ctx, bytearray())
 
 
-def move_single_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def move_single_request(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user moves an item in the stash (only in the stash screen)"""
     req = SC2S_INVENTORY_SINGLE_UPDATE_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/inventory.py
+++ b/dndserver/handlers/inventory.py
@@ -1,3 +1,5 @@
+from typing import Tuple, List
+
 from dndserver.database import db
 from dndserver.models import Character, Item, ItemAttribute
 from dndserver.persistent import sessions
@@ -17,9 +19,10 @@ from dndserver.protos.Inventory import (
     SS2C_INVENTORY_SWAP_RES,
     SS2C_INVENTORY_SPLIT_MERGE_RES,
 )
+from dndserver.protos.Lobby import SS2C_LOBBY_CHARACTER_INFO_RES
 
 
-def get_all_items(character_id, inventory_id=None, slot_id=None):
+def get_all_items(character_id, inventory_id=None, slot_id=None) -> List[Tuple[Item, List[ItemAttribute]]]:
     """Helper function to get all items for a character id"""
     query = db.query(Item).filter_by(character_id=character_id).filter_by(index=0)
 
@@ -41,7 +44,7 @@ def get_all_items(character_id, inventory_id=None, slot_id=None):
     return ret
 
 
-def delete_item(character_id, item, is_query=False):
+def delete_item(character_id, item, is_query=False) -> bool:
     """Helper function to remove a item from a character"""
     if is_query:
         query = item
@@ -63,7 +66,7 @@ def delete_item(character_id, item, is_query=False):
     return True
 
 
-def add_item(item):
+def add_item(item) -> None:
     """Helper function to add a item to a character"""
     it, attributes = item
 
@@ -74,7 +77,7 @@ def add_item(item):
         attribute.save()
 
 
-def get_stack_limit(item):
+def get_stack_limit(item) -> int:
     """Helper function to the get the amount we can stack a item"""
     # TODO: this should be read from the item directly
     if "Id_Item_Bandage" in item or "Potion" in item or "Id_Item_ThrowingKnife" in item:
@@ -89,7 +92,7 @@ def get_stack_limit(item):
         return 0
 
 
-def get_inv_limit(item):
+def get_inv_limit(item) -> int:
     """Helper function to get the max inventory count for a item"""
     # TODO: get real values for limits
     if "Id_Item_GoldCoinPurse" in item:
@@ -102,7 +105,7 @@ def get_inv_limit(item):
         return 0
 
 
-def split_item(from_item, item_id, to_inventory, to_slot, quantity, character_id, from_is_persistent=True):
+def split_item(from_item, item_id, to_inventory, to_slot, quantity, character_id, from_is_persistent=True) -> int:
     """Helper function to split a item and generate a new item at the provided location"""
     it = Item()
     it.character_id = character_id
@@ -149,7 +152,7 @@ def split_item(from_item, item_id, to_inventory, to_slot, quantity, character_id
     return it.id
 
 
-def merge_items(from_item, to_item, amount, character_id, from_is_persistent=True):
+def merge_items(from_item, to_item, amount, character_id, from_is_persistent=True) -> bool:
     """Helper function to merge two items."""
     # Check how we can merge the two items
     if get_inv_limit(from_item.item_id) and get_inv_limit(to_item.item_id):
@@ -194,7 +197,7 @@ def merge_items(from_item, to_item, amount, character_id, from_is_persistent=Tru
     return True
 
 
-def merge_request(ctx, msg):
+def merge_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user drags an item on another in the merchant screen."""
     req = SC2S_INVENTORY_MERGE_REQ()
     req.ParseFromString(msg)
@@ -217,7 +220,7 @@ def merge_request(ctx, msg):
     return HCharacter.character_info(ctx, bytearray())
 
 
-def split_move_request(ctx, msg):
+def split_move_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user wants to split an item in the merchant screen."""
     req = SC2S_INVENTORY_SPLIT_MOVE_REQ()
     req.ParseFromString(msg)
@@ -255,7 +258,7 @@ def split_move_request(ctx, msg):
     return HCharacter.character_info(ctx, bytearray())
 
 
-def swap_request(ctx, msg):
+def swap_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user wants to swap two items in the merchant screen."""
     req = SC2S_INVENTORY_SWAP_REQ()
     req.ParseFromString(msg)
@@ -279,7 +282,7 @@ def swap_request(ctx, msg):
     return HCharacter.character_info(ctx, bytearray())
 
 
-def split_merge_request(ctx, msg):
+def split_merge_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user wants to split and merge the result on another item in the merchant screen."""
     req = SC2S_INVENTORY_SPLIT_MERGE_REQ()
     req.ParseFromString(msg)
@@ -315,7 +318,7 @@ def split_merge_request(ctx, msg):
     return HCharacter.character_info(ctx, bytearray())
 
 
-def move_request(ctx, msg):
+def move_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user moves an item at a merchant"""
     req = SC2S_INVENTORY_MOVE_REQ()
     req.ParseFromString(msg)
@@ -341,7 +344,7 @@ def move_request(ctx, msg):
     return HCharacter.character_info(ctx, bytearray())
 
 
-def move_single_request(ctx, msg):
+def move_single_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user moves an item in the stash (only in the stash screen)"""
     req = SC2S_INVENTORY_SINGLE_UPDATE_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/item.py
+++ b/dndserver/handlers/item.py
@@ -10,6 +10,7 @@ from dndserver.enums.items import (
     EnhancementMagicWeapon,
     MagicWeapon,
     EnhancementArmor,
+    Material,
 )
 
 # TODO We might want to store this somewhere else, and only call it once, when server starts
@@ -34,7 +35,7 @@ def load_json_data() -> None:
 load_json_data()
 
 
-def get_content(name, type, rarity) -> dict:
+def get_content(name: str, type: ItemType, rarity: Rarity) -> dict:
     """Gets the relevant data depending on the item name and type"""
 
     content = {}
@@ -54,7 +55,7 @@ def get_content(name, type, rarity) -> dict:
     return content
 
 
-def get_content_based_on(material, item_type) -> Dict[str, Any]:
+def get_content_based_on(material: Material, item_type: ItemType) -> Dict[str, Any]:
     """Gets the relevant data depending on the material and type"""
 
     obj = {}
@@ -68,7 +69,7 @@ def get_content_based_on(material, item_type) -> Dict[str, Any]:
     return obj
 
 
-def random_gear(content, how_many) -> dict:
+def random_gear(content: dict, how_many: int) -> dict:
     """Return a random dictionary of how many items you want from a list of dictionaries (content)"""
 
     new_result = {}
@@ -81,7 +82,7 @@ def random_gear(content, how_many) -> dict:
     return new_result
 
 
-def random_item_list(type, material, item_count) -> List[Dict[str, Any]]:
+def random_item_list(type: ItemType, material: Material, item_count: int) -> List[Dict[str, Any]]:
     """Produce a list of random weapon or armor for merchants"""
     final_data = []
 
@@ -100,7 +101,7 @@ def random_item_list(type, material, item_count) -> List[Dict[str, Any]]:
     return final_data
 
 
-def random_rarity(list_of_rarity) -> Rarity:
+def random_rarity(list_of_rarity: List[Rarity]) -> Rarity:
     """Produce a random rarity for gear:
     gray = 45%; white = 35%; green = 24.50%; blue = 15.50%; purple = 8%;"""
 
@@ -117,7 +118,7 @@ def random_rarity(list_of_rarity) -> Rarity:
     return random.choices(list_of_rarity[1:-2], list_of_chance, k=1)[0]
 
 
-def generate_new_item(name, type, rarity, item_count=1) -> dict[str, Any]:
+def generate_new_item(name: str, type: ItemType, rarity: Rarity, item_count: int = 1) -> dict[str, Any]:
     """Function to be called in order to create an item"""
 
     final_data = {}
@@ -132,7 +133,7 @@ def generate_new_item(name, type, rarity, item_count=1) -> dict[str, Any]:
     return final_data
 
 
-def format_other_data(data, name, rarity, item_count) -> Dict[str, str]:
+def format_other_data(data: dict, name: str, rarity: Rarity, item_count: int) -> Dict[str, str]:
     """Raw data for non weapons/armors are different, so need to be fetched differently"""
 
     item_id = f"DesignDataItem:Id_Item_{name}_{rarity}001"
@@ -147,7 +148,7 @@ def format_other_data(data, name, rarity, item_count) -> Dict[str, str]:
     return final_data
 
 
-def parse_properties_to_array(data, rarity) -> List[dict]:
+def parse_properties_to_array(data: dict, rarity: str) -> List[dict]:
     """Gets the stat properties of the item data and formats it to be consumed"""
 
     properties = data["stats"][rarity]
@@ -158,7 +159,7 @@ def parse_properties_to_array(data, rarity) -> List[dict]:
     return properties_array
 
 
-def parse_secondary_properties_to_array(rarity, item_type, name) -> List[dict]:
+def parse_secondary_properties_to_array(rarity: str, item_type: ItemType, name: str) -> List[dict]:
     """Prepare the data for secondary property to be consumed"""
     rarity = int(rarity)
 
@@ -175,7 +176,7 @@ def parse_secondary_properties_to_array(rarity, item_type, name) -> List[dict]:
     return []
 
 
-def effects_based_on(rarity, item_type, name) -> List[dict]:
+def effects_based_on(rarity: str, item_type: ItemType, name: str) -> List[dict]:
     """Select random sencondary effects for weapons and armors"""
 
     properties_array = []
@@ -208,7 +209,7 @@ def effects_based_on(rarity, item_type, name) -> List[dict]:
     return properties_array
 
 
-def adjust_stats_based_on_ranges(property_array) -> List[dict]:
+def adjust_stats_based_on_ranges(property_array: List[dict]) -> List[dict]:
     """Generates the stats values depending on the value ranges in the data"""
 
     new_property_array = []
@@ -234,7 +235,7 @@ def adjust_stats_based_on_ranges(property_array) -> List[dict]:
     return new_property_array
 
 
-def format_data(data, name, rarity, item_type) -> dict:
+def format_data(data: dict, name: str, rarity: str, item_type: ItemType) -> dict:
     """Formats the itemId and properties by calling other formatters, formats the response to be consumed"""
 
     item_id = f"DesignDataItem:Id_Item_{name}_{rarity}001"

--- a/dndserver/handlers/item.py
+++ b/dndserver/handlers/item.py
@@ -1,6 +1,8 @@
 import json
 import os
 import random
+from typing import List, Dict, Any
+
 from dndserver.enums.items import (
     ItemType,
     Rarity,
@@ -14,7 +16,7 @@ from dndserver.enums.items import (
 json_data = {}
 
 
-def load_json_data():
+def load_json_data() -> None:
     current_dir = os.path.dirname(os.path.abspath(__file__))
     for item_type in ItemType:
         type = str(item_type.value)
@@ -32,7 +34,7 @@ def load_json_data():
 load_json_data()
 
 
-def get_content(name, type, rarity):
+def get_content(name, type, rarity) -> dict:
     """Gets the relevant data depending on the item name and type"""
 
     content = {}
@@ -52,7 +54,7 @@ def get_content(name, type, rarity):
     return content
 
 
-def get_content_based_on(material, item_type):
+def get_content_based_on(material, item_type) -> Dict[str, Any]:
     """Gets the relevant data depending on the material and type"""
 
     obj = {}
@@ -66,7 +68,7 @@ def get_content_based_on(material, item_type):
     return obj
 
 
-def random_gear(content, how_many):
+def random_gear(content, how_many) -> dict:
     """Return a random dictionary of how many items you want from a list of dictionaries (content)"""
 
     new_result = {}
@@ -79,7 +81,7 @@ def random_gear(content, how_many):
     return new_result
 
 
-def random_item_list(type, material, item_count):
+def random_item_list(type, material, item_count) -> List[Dict[str, Any]]:
     """Produce a list of random weapon or armor for merchants"""
     final_data = []
 
@@ -98,7 +100,7 @@ def random_item_list(type, material, item_count):
     return final_data
 
 
-def random_rarity(list_of_rarity):
+def random_rarity(list_of_rarity) -> Rarity:
     """Produce a random rarity for gear:
     gray = 45%; white = 35%; green = 24.50%; blue = 15.50%; purple = 8%;"""
 
@@ -115,7 +117,7 @@ def random_rarity(list_of_rarity):
     return random.choices(list_of_rarity[1:-2], list_of_chance, k=1)[0]
 
 
-def generate_new_item(name, type, rarity, item_count=1):
+def generate_new_item(name, type, rarity, item_count=1) -> dict[str, Any]:
     """Function to be called in order to create an item"""
 
     final_data = {}
@@ -130,7 +132,7 @@ def generate_new_item(name, type, rarity, item_count=1):
     return final_data
 
 
-def format_other_data(data, name, rarity, item_count):
+def format_other_data(data, name, rarity, item_count) -> Dict[str, str]:
     """Raw data for non weapons/armors are different, so need to be fetched differently"""
 
     item_id = f"DesignDataItem:Id_Item_{name}_{rarity}001"
@@ -145,7 +147,7 @@ def format_other_data(data, name, rarity, item_count):
     return final_data
 
 
-def parse_properties_to_array(data, rarity):
+def parse_properties_to_array(data, rarity) -> List[dict]:
     """Gets the stat properties of the item data and formats it to be consumed"""
 
     properties = data["stats"][rarity]
@@ -156,7 +158,7 @@ def parse_properties_to_array(data, rarity):
     return properties_array
 
 
-def parse_secondary_properties_to_array(rarity, item_type, name):
+def parse_secondary_properties_to_array(rarity, item_type, name) -> List[dict]:
     """Prepare the data for secondary property to be consumed"""
     rarity = int(rarity)
 
@@ -173,7 +175,7 @@ def parse_secondary_properties_to_array(rarity, item_type, name):
     return []
 
 
-def effects_based_on(rarity, item_type, name):
+def effects_based_on(rarity, item_type, name) -> List[dict]:
     """Select random sencondary effects for weapons and armors"""
 
     properties_array = []
@@ -206,7 +208,7 @@ def effects_based_on(rarity, item_type, name):
     return properties_array
 
 
-def adjust_stats_based_on_ranges(property_array):
+def adjust_stats_based_on_ranges(property_array) -> List[dict]:
     """Generates the stats values depending on the value ranges in the data"""
 
     new_property_array = []
@@ -232,7 +234,7 @@ def adjust_stats_based_on_ranges(property_array):
     return new_property_array
 
 
-def format_data(data, name, rarity, item_type):
+def format_data(data, name, rarity, item_type) -> dict:
     """Formats the itemId and properties by calling other formatters, formats the response to be consumed"""
 
     item_id = f"DesignDataItem:Id_Item_{name}_{rarity}001"

--- a/dndserver/handlers/lobby.py
+++ b/dndserver/handlers/lobby.py
@@ -18,7 +18,7 @@ from dndserver.protos.Lobby import (
 )
 
 
-def enter_lobby(ctx, msg) -> SS2C_LOBBY_ENTER_RES:
+def enter_lobby(ctx, msg: bytes) -> SS2C_LOBBY_ENTER_RES:
     """Occurs when loading into the lobby from the character selection screen."""
     req = SC2S_LOBBY_ENTER_REQ()
     req.ParseFromString(msg)
@@ -38,7 +38,7 @@ def enter_lobby(ctx, msg) -> SS2C_LOBBY_ENTER_RES:
     return res
 
 
-def region_select(ctx, msg) -> SS2C_LOBBY_REGION_SELECT_RES:
+def region_select(ctx, msg: bytes) -> SS2C_LOBBY_REGION_SELECT_RES:
     """Occurs when a user changes the game server region."""
     req = SC2S_LOBBY_REGION_SELECT_REQ()
     req.ParseFromString(msg)
@@ -46,7 +46,7 @@ def region_select(ctx, msg) -> SS2C_LOBBY_REGION_SELECT_RES:
     return res
 
 
-def start(ctx, msg) -> SS2C_CHARACTER_SELECT_ENTER_RES:
+def start(ctx, msg: bytes) -> SS2C_CHARACTER_SELECT_ENTER_RES:
     """Currently unused."""
     req = SC2S_CHARACTER_SELECT_ENTER_REQ()
     req.ParseFromString(msg)
@@ -54,13 +54,13 @@ def start(ctx, msg) -> SS2C_CHARACTER_SELECT_ENTER_RES:
     return res
 
 
-def enter_character_select(ctx, msg) -> SS2C_CHARACTER_SELECT_ENTER_RES:
+def enter_character_select(ctx, msg: bytes) -> SS2C_CHARACTER_SELECT_ENTER_RES:
     """Occurs when client enter in the characters selection menu."""
     res = SS2C_CHARACTER_SELECT_ENTER_RES(result=1)
     return res
 
 
-def map_select(ctx, msg) -> SS2C_LOBBY_GAME_DIFFICULTY_SELECT_RES:
+def map_select(ctx, msg: bytes) -> SS2C_LOBBY_GAME_DIFFICULTY_SELECT_RES:
     """Occurs when client selects a map."""
     req = SC2S_LOBBY_GAME_DIFFICULTY_SELECT_REQ()
     req.ParseFromString(msg)
@@ -68,7 +68,7 @@ def map_select(ctx, msg) -> SS2C_LOBBY_GAME_DIFFICULTY_SELECT_RES:
     return res
 
 
-def open_map_select(ctx, msg) -> SS2C_OPEN_LOBBY_MAP_RES:
+def open_map_select(ctx, msg: bytes) -> SS2C_OPEN_LOBBY_MAP_RES:
     """Occurs when client opens the map selector."""
     req = SC2S_OPEN_LOBBY_MAP_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/lobby.py
+++ b/dndserver/handlers/lobby.py
@@ -18,7 +18,7 @@ from dndserver.protos.Lobby import (
 )
 
 
-def enter_lobby(ctx, msg):
+def enter_lobby(ctx, msg) -> SS2C_LOBBY_ENTER_RES:
     """Occurs when loading into the lobby from the character selection screen."""
     req = SC2S_LOBBY_ENTER_REQ()
     req.ParseFromString(msg)
@@ -38,7 +38,7 @@ def enter_lobby(ctx, msg):
     return res
 
 
-def region_select(ctx, msg):
+def region_select(ctx, msg) -> SS2C_LOBBY_REGION_SELECT_RES:
     """Occurs when a user changes the game server region."""
     req = SC2S_LOBBY_REGION_SELECT_REQ()
     req.ParseFromString(msg)
@@ -46,7 +46,7 @@ def region_select(ctx, msg):
     return res
 
 
-def start(ctx, msg):
+def start(ctx, msg) -> SS2C_CHARACTER_SELECT_ENTER_RES:
     """Currently unused."""
     req = SC2S_CHARACTER_SELECT_ENTER_REQ()
     req.ParseFromString(msg)
@@ -54,13 +54,13 @@ def start(ctx, msg):
     return res
 
 
-def enter_character_select(ctx, msg):
+def enter_character_select(ctx, msg) -> SS2C_CHARACTER_SELECT_ENTER_RES:
     """Occurs when client enter in the characters selection menu."""
     res = SS2C_CHARACTER_SELECT_ENTER_RES(result=1)
     return res
 
 
-def map_select(ctx, msg):
+def map_select(ctx, msg) -> SS2C_LOBBY_GAME_DIFFICULTY_SELECT_RES:
     """Occurs when client selects a map."""
     req = SC2S_LOBBY_GAME_DIFFICULTY_SELECT_REQ()
     req.ParseFromString(msg)
@@ -68,7 +68,7 @@ def map_select(ctx, msg):
     return res
 
 
-def open_map_select(ctx, msg):
+def open_map_select(ctx, msg) -> SS2C_OPEN_LOBBY_MAP_RES:
     """Occurs when client opens the map selector."""
     req = SC2S_OPEN_LOBBY_MAP_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/login.py
+++ b/dndserver/handlers/login.py
@@ -11,7 +11,7 @@ from dndserver.protos.Account import SC2S_ACCOUNT_LOGIN_REQ, SLOGIN_ACCOUNT_INFO
 from dndserver.protos.Common import SS2C_SERVICE_POLICY_NOT, FSERVICE_POLICY
 
 
-def process_login(ctx, msg):
+def process_login(ctx, msg) -> SS2C_ACCOUNT_LOGIN_RES:
     """Occurs when the user attempts to login to the game server."""
     req = SC2S_ACCOUNT_LOGIN_REQ()
     req.ParseFromString(msg)
@@ -71,7 +71,7 @@ def process_login(ctx, msg):
     return res
 
 
-def service_policy_notification(ctx):
+def service_policy_notification(ctx) -> None:
     # Fix for Ante (High-Roller Entrance Fee)
     # Policy Type '7' referes to High-Roller
     # There's a lot more policy types, all with values, still unknown what each type does.
@@ -82,7 +82,7 @@ def service_policy_notification(ctx):
     ctx.reply(notify)
 
 
-def kick_concurrent_user(newly_connected_account):
+def kick_concurrent_user(newly_connected_account) -> None:
     """Searches for already connected account and kicks if a match is found."""
     for transport, user in sessions.items():
         # case where a duplicate account is found

--- a/dndserver/handlers/login.py
+++ b/dndserver/handlers/login.py
@@ -11,7 +11,7 @@ from dndserver.protos.Account import SC2S_ACCOUNT_LOGIN_REQ, SLOGIN_ACCOUNT_INFO
 from dndserver.protos.Common import SS2C_SERVICE_POLICY_NOT, FSERVICE_POLICY
 
 
-def process_login(ctx, msg) -> SS2C_ACCOUNT_LOGIN_RES:
+def process_login(ctx, msg: bytes) -> SS2C_ACCOUNT_LOGIN_RES:
     """Occurs when the user attempts to login to the game server."""
     req = SC2S_ACCOUNT_LOGIN_REQ()
     req.ParseFromString(msg)
@@ -82,7 +82,7 @@ def service_policy_notification(ctx) -> None:
     ctx.reply(notify)
 
 
-def kick_concurrent_user(newly_connected_account) -> None:
+def kick_concurrent_user(newly_connected_account: Account) -> None:
     """Searches for already connected account and kicks if a match is found."""
     for transport, user in sessions.items():
         # case where a duplicate account is found

--- a/dndserver/handlers/menu.py
+++ b/dndserver/handlers/menu.py
@@ -3,7 +3,7 @@ from dndserver.persistent import sessions
 from dndserver.handlers.party import get_party, send_party_location_notification
 
 
-def process_location(ctx, msg) -> SS2C_META_LOCATION_RES:
+def process_location(ctx, msg: bytes) -> SS2C_META_LOCATION_RES:
     # get the location from the message.
     req = SC2S_META_LOCATION_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/menu.py
+++ b/dndserver/handlers/menu.py
@@ -3,7 +3,7 @@ from dndserver.persistent import sessions
 from dndserver.handlers.party import get_party, send_party_location_notification
 
 
-def process_location(ctx, msg):
+def process_location(ctx, msg) -> SS2C_META_LOCATION_RES:
     # get the location from the message.
     req = SC2S_META_LOCATION_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/merchant.py
+++ b/dndserver/handlers/merchant.py
@@ -24,12 +24,14 @@ from dndserver.protos.Merchant import (
     SS2C_MERCHANT_STOCK_SELL_BACK_ITEM_LIST_RES,
     SC2S_MERCHANT_STOCK_SELL_BACK_REQ,
     SS2C_MERCHANT_STOCK_SELL_BACK_RES,
+    SMERCHANT_TRADE_SLOT_INFO,
 )
 from dndserver.handlers import character, inventory
 from dndserver.protos.Lobby import SS2C_LOBBY_CHARACTER_INFO_RES
+from dndserver.protos.Item import SItem
 
 
-def delete_items_merchant(merchant_id) -> None:
+def delete_items_merchant(merchant_id: int) -> None:
     """Helper function to delete all items a merchant has"""
     items = db.query(Item).filter_by(merchant_id=merchant_id).all()
 
@@ -43,7 +45,7 @@ def delete_items_merchant(merchant_id) -> None:
         item.delete()
 
 
-def delete_merchants(character_id) -> None:
+def delete_merchants(character_id: int) -> None:
     """Helper function to delete all merchants and items they have"""
     merchants = db.query(Merchant).filter_by(character_id=character_id).all()
 
@@ -55,7 +57,7 @@ def delete_merchants(character_id) -> None:
         merchant.delete()
 
 
-def create_merchants(character_id) -> None:
+def create_merchants(character_id: int) -> None:
     """Helper function to create merchants for a character"""
     # create all the merchants for the user
     for merchant in MerchantClass:
@@ -63,7 +65,7 @@ def create_merchants(character_id) -> None:
         db_create_merchant(character_id, merchant, arrow.utcnow().shift(minutes=15))
 
 
-def get_stockbuy_id(merchant, index) -> str:
+def get_stockbuy_id(merchant: MerchantClass, index: int) -> str:
     """Helper to create the string for the stockbuy id"""
     ret = "DesignDataStockBuy:Id_StockBuy_"
 
@@ -99,13 +101,13 @@ def get_stockbuy_id(merchant, index) -> str:
     return ret + "_{0:0>2}".format(index)
 
 
-def get_stock_unique_id(merchant, index) -> int:
+def get_stock_unique_id(merchant: MerchantClass, index: int) -> int:
     """Helper function to get the stock unique id for the merchant and index"""
     # TODO: use the mapping for the stock unique id. For now use the index
     return index
 
 
-def db_create_merchant(character_id, merchant_class, refresh_time) -> None:
+def db_create_merchant(character_id: int, merchant_class: MerchantClass, refresh_time: arrow.Arrow) -> None:
     """Helper function to create a merchant in the database"""
     merchant = Merchant()
     merchant.character_id = character_id
@@ -115,7 +117,9 @@ def db_create_merchant(character_id, merchant_class, refresh_time) -> None:
     merchant.save()
 
 
-def db_create_merchant_item(merchant_id, item, index, remaining, character_id) -> None:
+def db_create_merchant_item(
+    merchant_id: int, item: SItem, index: int, remaining: arrow.Arrow, character_id: int
+) -> None:
     """Creates a database entry for the merchant with item attributes and the amount remaining"""
     it = Item()
     it.character_id = character_id
@@ -151,7 +155,7 @@ def db_create_merchant_item(merchant_id, item, index, remaining, character_id) -
         attr.save()
 
 
-def generate_items_merchant(merchant, merchant_id, character_id) -> None:
+def generate_items_merchant(merchant: MerchantClass, merchant_id: int, character_id: int) -> None:
     """Helper to generate items for a merchant"""
     items = ObjItems.generate_merch_items(merchant)
     # get the stock index map for the current merchant (never add 2 items within the
@@ -166,7 +170,7 @@ def generate_items_merchant(merchant, merchant_id, character_id) -> None:
         db_create_merchant_item(merchant_id, item, index, remaining, character_id)
 
 
-def add_to_inventory_merchant(unique_id, info, character_id) -> bool:
+def add_to_inventory_merchant(unique_id: int, info: SMERCHANT_TRADE_SLOT_INFO, character_id: int) -> bool:
     """Helper function to add a bought item to the inventory of the character"""
     # get the selected item from the database
     item = db.query(Item).filter_by(character_id=character_id).filter_by(index=unique_id).first()
@@ -213,7 +217,7 @@ def add_to_inventory_merchant(unique_id, info, character_id) -> bool:
     return True
 
 
-def get_merchant_list(ctx, msg) -> SS2C_MERCHANT_LIST_RES:
+def get_merchant_list(ctx, msg: bytes) -> SS2C_MERCHANT_LIST_RES:
     """Occurs when the user opens the merchant menu"""
     # get all the times for every merchant
     merchants = db.query(Merchant).filter_by(character_id=sessions[ctx.transport].character.id).all()
@@ -253,7 +257,7 @@ def get_merchant_list(ctx, msg) -> SS2C_MERCHANT_LIST_RES:
     return res
 
 
-def get_buy_list(ctx, msg) -> SS2C_MERCHANT_STOCK_BUY_ITEM_LIST_RES:
+def get_buy_list(ctx, msg: bytes) -> SS2C_MERCHANT_STOCK_BUY_ITEM_LIST_RES:
     """Occurs when the user opens one of the merchant menus"""
     # To list the stock we need to send 3 messages.
     # 1 for starting, 1 with the actual data and the last for the end
@@ -343,7 +347,7 @@ def get_buy_list(ctx, msg) -> SS2C_MERCHANT_STOCK_BUY_ITEM_LIST_RES:
     )
 
 
-def buy_item(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def buy_item(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user buys a item from the merchant"""
     req = SC2S_MERCHANT_STOCK_BUY_REQ()
     req.ParseFromString(msg)
@@ -383,7 +387,7 @@ def buy_item(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     return character.character_info(ctx=ctx, msg=bytearray())
 
 
-def get_sellback_list(ctx, msg) -> SS2C_MERCHANT_STOCK_SELL_BACK_ITEM_LIST_RES:
+def get_sellback_list(ctx, msg: bytes) -> SS2C_MERCHANT_STOCK_SELL_BACK_ITEM_LIST_RES:
     """Occurs when the user opens one of the merchant menus"""
     # To send the items we can sell back to the merchant we need to send 3 messages.
     # 1 for starting, 1 with the actual data and the last for the end
@@ -419,7 +423,7 @@ def get_sellback_list(ctx, msg) -> SS2C_MERCHANT_STOCK_SELL_BACK_ITEM_LIST_RES:
     )
 
 
-def sellback_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
+def sellback_request(ctx, msg: bytes) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user requests to sellback to one of the merchants."""
     req = SC2S_MERCHANT_STOCK_SELL_BACK_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/merchant.py
+++ b/dndserver/handlers/merchant.py
@@ -26,9 +26,10 @@ from dndserver.protos.Merchant import (
     SS2C_MERCHANT_STOCK_SELL_BACK_RES,
 )
 from dndserver.handlers import character, inventory
+from dndserver.protos.Lobby import SS2C_LOBBY_CHARACTER_INFO_RES
 
 
-def delete_items_merchant(merchant_id):
+def delete_items_merchant(merchant_id) -> None:
     """Helper function to delete all items a merchant has"""
     items = db.query(Item).filter_by(merchant_id=merchant_id).all()
 
@@ -42,7 +43,7 @@ def delete_items_merchant(merchant_id):
         item.delete()
 
 
-def delete_merchants(character_id):
+def delete_merchants(character_id) -> None:
     """Helper function to delete all merchants and items they have"""
     merchants = db.query(Merchant).filter_by(character_id=character_id).all()
 
@@ -54,7 +55,7 @@ def delete_merchants(character_id):
         merchant.delete()
 
 
-def create_merchants(character_id):
+def create_merchants(character_id) -> None:
     """Helper function to create merchants for a character"""
     # create all the merchants for the user
     for merchant in MerchantClass:
@@ -62,7 +63,7 @@ def create_merchants(character_id):
         db_create_merchant(character_id, merchant, arrow.utcnow().shift(minutes=15))
 
 
-def get_stockbuy_id(merchant, index):
+def get_stockbuy_id(merchant, index) -> str:
     """Helper to create the string for the stockbuy id"""
     ret = "DesignDataStockBuy:Id_StockBuy_"
 
@@ -98,13 +99,13 @@ def get_stockbuy_id(merchant, index):
     return ret + "_{0:0>2}".format(index)
 
 
-def get_stock_unique_id(merchant, index):
+def get_stock_unique_id(merchant, index) -> int:
     """Helper function to get the stock unique id for the merchant and index"""
     # TODO: use the mapping for the stock unique id. For now use the index
     return index
 
 
-def db_create_merchant(character_id, merchant_class, refresh_time):
+def db_create_merchant(character_id, merchant_class, refresh_time) -> None:
     """Helper function to create a merchant in the database"""
     merchant = Merchant()
     merchant.character_id = character_id
@@ -114,7 +115,7 @@ def db_create_merchant(character_id, merchant_class, refresh_time):
     merchant.save()
 
 
-def db_create_merchant_item(merchant_id, item, index, remaining, character_id):
+def db_create_merchant_item(merchant_id, item, index, remaining, character_id) -> None:
     """Creates a database entry for the merchant with item attributes and the amount remaining"""
     it = Item()
     it.character_id = character_id
@@ -150,7 +151,7 @@ def db_create_merchant_item(merchant_id, item, index, remaining, character_id):
         attr.save()
 
 
-def generate_items_merchant(merchant, merchant_id, character_id):
+def generate_items_merchant(merchant, merchant_id, character_id) -> None:
     """Helper to generate items for a merchant"""
     items = ObjItems.generate_merch_items(merchant)
     # get the stock index map for the current merchant (never add 2 items within the
@@ -165,7 +166,7 @@ def generate_items_merchant(merchant, merchant_id, character_id):
         db_create_merchant_item(merchant_id, item, index, remaining, character_id)
 
 
-def add_to_inventory_merchant(unique_id, info, character_id):
+def add_to_inventory_merchant(unique_id, info, character_id) -> bool:
     """Helper function to add a bought item to the inventory of the character"""
     # get the selected item from the database
     item = db.query(Item).filter_by(character_id=character_id).filter_by(index=unique_id).first()
@@ -212,7 +213,7 @@ def add_to_inventory_merchant(unique_id, info, character_id):
     return True
 
 
-def get_merchant_list(ctx, msg):
+def get_merchant_list(ctx, msg) -> SS2C_MERCHANT_LIST_RES:
     """Occurs when the user opens the merchant menu"""
     # get all the times for every merchant
     merchants = db.query(Merchant).filter_by(character_id=sessions[ctx.transport].character.id).all()
@@ -252,7 +253,7 @@ def get_merchant_list(ctx, msg):
     return res
 
 
-def get_buy_list(ctx, msg):
+def get_buy_list(ctx, msg) -> SS2C_MERCHANT_STOCK_BUY_ITEM_LIST_RES:
     """Occurs when the user opens one of the merchant menus"""
     # To list the stock we need to send 3 messages.
     # 1 for starting, 1 with the actual data and the last for the end
@@ -342,7 +343,7 @@ def get_buy_list(ctx, msg):
     )
 
 
-def buy_item(ctx, msg):
+def buy_item(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user buys a item from the merchant"""
     req = SC2S_MERCHANT_STOCK_BUY_REQ()
     req.ParseFromString(msg)
@@ -382,7 +383,7 @@ def buy_item(ctx, msg):
     return character.character_info(ctx=ctx, msg=bytearray())
 
 
-def get_sellback_list(ctx, msg):
+def get_sellback_list(ctx, msg) -> SS2C_MERCHANT_STOCK_SELL_BACK_ITEM_LIST_RES:
     """Occurs when the user opens one of the merchant menus"""
     # To send the items we can sell back to the merchant we need to send 3 messages.
     # 1 for starting, 1 with the actual data and the last for the end
@@ -418,7 +419,7 @@ def get_sellback_list(ctx, msg):
     )
 
 
-def sellback_request(ctx, msg):
+def sellback_request(ctx, msg) -> SS2C_LOBBY_CHARACTER_INFO_RES:
     """Occurs when the user requests to sellback to one of the merchants."""
     req = SC2S_MERCHANT_STOCK_SELL_BACK_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/party.py
+++ b/dndserver/handlers/party.py
@@ -30,7 +30,7 @@ from dndserver.protos.Party import (
 from dndserver.utils import get_party, get_user, make_header
 
 
-def party_invite(ctx, msg):
+def party_invite(ctx, msg) -> SS2C_PARTY_INVITE_RES:
     """Occurs when a user sends a party to another user."""
     req = SC2S_PARTY_INVITE_REQ()
     req.ParseFromString(msg)
@@ -44,7 +44,7 @@ def party_invite(ctx, msg):
     return SS2C_PARTY_INVITE_RES(result=pc.SUCCESS)
 
 
-def accept_invite(ctx, msg):
+def accept_invite(ctx, msg) -> SS2C_PARTY_INVITE_ANSWER_RES:
     """Occurs when a user accepts a party invite."""
     # req.returnAccountId == inviter
     # sessions[ctx.transport].account.id == invitee
@@ -85,7 +85,7 @@ def accept_invite(ctx, msg):
     return SS2C_PARTY_INVITE_ANSWER_RES(result=pc.SUCCESS)
 
 
-def send_invite_notification(ctx, req):
+def send_invite_notification(ctx, req) -> None:
     notify = SS2C_PARTY_INVITE_NOT(
         InviteeNickName=SACCOUNT_NICKNAME(
             originalNickName=sessions[ctx.transport].character.nickname,
@@ -102,7 +102,7 @@ def send_invite_notification(ctx, req):
     transport.write(header + notify.SerializeToString())
 
 
-def send_accept_notification(ctx, req):
+def send_accept_notification(ctx, req) -> None:
     transport, _ = get_user(account_id=int(req.returnAccountId))
     notify = SS2C_PARTY_INVITE_ANSWER_RESULT_NOT(
         nickName=SACCOUNT_NICKNAME(
@@ -116,7 +116,7 @@ def send_accept_notification(ctx, req):
     transport.write(header + notify.SerializeToString())
 
 
-def send_party_info_notification(party):
+def send_party_info_notification(party) -> None:
     """Notification sent to all players in the lobby that updates the current party player list."""
     notify = SS2C_PARTY_MEMBER_INFO_NOT()
     for user in party.players:
@@ -148,7 +148,7 @@ def send_party_info_notification(party):
         transport.write(header + notify.SerializeToString())
 
 
-def send_party_location_notification(party, session):
+def send_party_location_notification(party, session) -> None:
     """Notification send the other party members that updates the location of the provided user"""
     notify = SS2C_PARTY_LOCATION_UPDATE_NOT()
     notify.accountId = str(session.account.id)
@@ -165,7 +165,7 @@ def send_party_location_notification(party, session):
         transport.write(header + notify.SerializeToString())
 
 
-def leave_party(ctx, msg):
+def leave_party(ctx, msg) -> SS2C_PARTY_EXIT_RES:
     """Occurs when a user leaves the party."""
     req = SC2S_PARTY_EXIT_REQ()
     req.ParseFromString(msg)
@@ -194,7 +194,7 @@ def leave_party(ctx, msg):
     return SS2C_PARTY_EXIT_RES(result=pc.SUCCESS)
 
 
-def set_ready_state(ctx, msg):
+def set_ready_state(ctx, msg) -> SS2C_PARTY_READY_RES:
     """Occurs when a user presses the ready button in a party."""
     req = SC2S_PARTY_READY_REQ()
     req.ParseFromString(msg)
@@ -209,7 +209,7 @@ def set_ready_state(ctx, msg):
     return SS2C_PARTY_READY_RES(result=pc.SUCCESS)
 
 
-def kick_member(ctx, msg):
+def kick_member(ctx, msg) -> SS2C_PARTY_MEMBER_KICK_RES:
     """Occurs when party leader clicks on Kick"""
     req = SC2S_PARTY_MEMBER_KICK_REQ()
     req.ParseFromString(msg)
@@ -228,7 +228,7 @@ def kick_member(ctx, msg):
         return SS2C_PARTY_MEMBER_KICK_RES(result=pc.FAIL_GENERAL)
 
 
-def broadcast_chat(ctx, msg):
+def broadcast_chat(ctx, msg) -> None:
     res = SS2C_PARTY_CHAT_NOT(chatData=msg, time=int(round(datetime.now().timestamp() * 1000)))
     party = get_party(account_id=sessions[ctx.transport].account.id)
     header = make_header(res)
@@ -237,7 +237,7 @@ def broadcast_chat(ctx, msg):
         transport.write(header + res.SerializeToString())
 
 
-def chat(ctx, msg):
+def chat(ctx, msg) -> SS2C_PARTY_CHAT_RES:
     req = SC2S_PARTY_CHAT_REQ()
     req.ParseFromString(msg)
     character = sessions[ctx.transport].character

--- a/dndserver/handlers/ranking.py
+++ b/dndserver/handlers/ranking.py
@@ -14,7 +14,7 @@ from dndserver.protos.Ranking import (
 )
 
 
-def get_character_ranking(ctx, msg):
+def get_character_ranking(ctx, msg) -> SS2C_RANKING_CHARACTER_RES:
     """Occurs when the user opens the leaderboards to view the rank in the leaderboard."""
     req = SC2S_RANKING_CHARACTER_REQ()
     req.ParseFromString(msg)
@@ -45,7 +45,7 @@ def get_character_ranking(ctx, msg):
     return res
 
 
-def get_ranking(ctx, msg):
+def get_ranking(ctx, msg) -> SS2C_RANKING_RANGE_RES:
     """Occurs when the user opens the leaderboards."""
     req = SC2S_RANKING_RANGE_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/ranking.py
+++ b/dndserver/handlers/ranking.py
@@ -14,7 +14,7 @@ from dndserver.protos.Ranking import (
 )
 
 
-def get_character_ranking(ctx, msg) -> SS2C_RANKING_CHARACTER_RES:
+def get_character_ranking(ctx, msg: bytes) -> SS2C_RANKING_CHARACTER_RES:
     """Occurs when the user opens the leaderboards to view the rank in the leaderboard."""
     req = SC2S_RANKING_CHARACTER_REQ()
     req.ParseFromString(msg)
@@ -45,7 +45,7 @@ def get_character_ranking(ctx, msg) -> SS2C_RANKING_CHARACTER_RES:
     return res
 
 
-def get_ranking(ctx, msg) -> SS2C_RANKING_RANGE_RES:
+def get_ranking(ctx, msg: bytes) -> SS2C_RANKING_RANGE_RES:
     """Occurs when the user opens the leaderboards."""
     req = SC2S_RANKING_RANGE_REQ()
     req.ParseFromString(msg)

--- a/dndserver/handlers/trade.py
+++ b/dndserver/handlers/trade.py
@@ -6,12 +6,12 @@ from dndserver.protos.Trade import (
 )
 
 
-def get_trade_reqs(ctx, msg) -> SS2C_TRADE_MEMBERSHIP_REQUIREMENT_RES:
+def get_trade_reqs(ctx, msg: bytes) -> SS2C_TRADE_MEMBERSHIP_REQUIREMENT_RES:
     return SS2C_TRADE_MEMBERSHIP_REQUIREMENT_RES(
         # TODO: Unsure what these values are actually supposed to look like.
         requirements=[STRADE_MEMBERSHIP_REQUIREMENT(memberShipType=1, memberShipValue=1)]
     )
 
 
-def process_membership(ctx, msg) -> SS2C_TRADE_MEMBERSHIP_RES:
+def process_membership(ctx, msg: bytes) -> SS2C_TRADE_MEMBERSHIP_RES:
     return SS2C_TRADE_MEMBERSHIP_RES(result=pc.SUCCESS)

--- a/dndserver/handlers/trade.py
+++ b/dndserver/handlers/trade.py
@@ -6,12 +6,12 @@ from dndserver.protos.Trade import (
 )
 
 
-def get_trade_reqs(ctx, msg):
+def get_trade_reqs(ctx, msg) -> SS2C_TRADE_MEMBERSHIP_REQUIREMENT_RES:
     return SS2C_TRADE_MEMBERSHIP_REQUIREMENT_RES(
         # TODO: Unsure what these values are actually supposed to look like.
         requirements=[STRADE_MEMBERSHIP_REQUIREMENT(memberShipType=1, memberShipValue=1)]
     )
 
 
-def process_membership(ctx, msg):
+def process_membership(ctx, msg) -> SS2C_TRADE_MEMBERSHIP_RES:
     return SS2C_TRADE_MEMBERSHIP_RES(result=pc.SUCCESS)

--- a/dndserver/models.py
+++ b/dndserver/models.py
@@ -22,7 +22,7 @@ class Account(base):
     created_at = Column(ArrowType, default=arrow.utcnow())
     ban_type = Column(Integer)
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
@@ -57,11 +57,11 @@ class Character(base):
     ranking_ghostking = Column(Integer, default=0)
     # TODO: store all logins in a database and grab the latest from that
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 
@@ -75,11 +75,11 @@ class Spell(base):
     slot_id = Column(Integer)
     sequence_id = Column(Integer)
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 
@@ -103,11 +103,11 @@ class Item(base):
     remaining = Column(Integer, default=0)
     index = Column(Integer, default=0)
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 
@@ -121,11 +121,11 @@ class ItemAttribute(base):
     property = Column(String)
     value = Column(Integer)
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 
@@ -138,11 +138,11 @@ class Merchant(base):
     merchant = Column(Enum(MerchantClass))
     refresh_time = Column(ArrowType, default=arrow.utcnow())
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 
@@ -156,11 +156,11 @@ class Hwid(base):
     is_banned = Column(Boolean)
     seen_at = Column(ArrowType, default=arrow.utcnow())
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 
@@ -177,11 +177,11 @@ class BlockedUser(base):
     character_class = Column(Enum(CharacterClass))
     blocked_at = Column(ArrowType, default=arrow.utcnow())
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 
@@ -195,11 +195,11 @@ class ChatLog(base):
     chat_index = Column(Integer)
     sent_at = Column(ArrowType, default=arrow.utcnow())
 
-    def save(self):
+    def save(self) -> None:
         db.add(self)
         db.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         db.delete(self)
         db.commit()
 

--- a/dndserver/objects/items.py
+++ b/dndserver/objects/items.py
@@ -1,10 +1,11 @@
-from typing import Tuple, List
+from typing import Tuple, List, Any
 
 from dndserver.handlers import item as hItem
 from dndserver.protos import Item as item
 from dndserver.data import merchant
-from dndserver.enums.items import ItemType, Material
+from dndserver.enums.items import ItemType, Material, Rarity, Item as ItemEnum
 from dndserver.enums.classes import MerchantClass
+from dndserver.protos.Defines import Define_Item, Define_Equipment
 
 
 class Item:
@@ -46,11 +47,20 @@ class Item:
             new_item.secondaryPropertyArray.append(new_prop)
 
 
-def generate_item(name, type, rarity, inventoryId, slotId, item_count=1) -> item.SItem:
+def generate_item(
+    name: ItemEnum,
+    type: ItemType,
+    rarity: Rarity,
+    inventoryId: Define_Item.InventoryId,
+    slotId: Define_Equipment.SlotId,
+    item_count: int = 1,
+) -> item.SItem:
     return item_parser(hItem.generate_new_item(name.value, type, rarity, item_count), inventoryId, slotId, item_count)
 
 
-def item_parser(item_values, inventoryId, slotId, item_count) -> item.SItem:
+def item_parser(
+    item_values: dict[str, Any], inventoryId: Define_Item.InventoryId, slotId: Define_Equipment.SlotId, item_count: int
+) -> item.SItem:
     newItem = item.SItem()
     newItem.inventoryId = inventoryId
     newItem.slotId = slotId
@@ -78,7 +88,7 @@ def item_parser(item_values, inventoryId, slotId, item_count) -> item.SItem:
     return newItem
 
 
-def generate_random_item(merch_id, amount) -> List[Tuple[item.SItem, int]]:
+def generate_random_item(merch_id: MerchantClass, amount: int) -> List[Tuple[item.SItem, int]]:
     ret = []
 
     # TODO: Add Merchants when we know what they sell
@@ -125,7 +135,7 @@ def generate_random_item(merch_id, amount) -> List[Tuple[item.SItem, int]]:
     return sorted_ret
 
 
-def generate_merch_items(merch_id) -> List[Tuple[item.SItem, int]]:
+def generate_merch_items(merch_id: MerchantClass) -> List[Tuple[item.SItem, int]]:
     items = merchant.fixed_items[merch_id]
     ret = []
 

--- a/dndserver/objects/items.py
+++ b/dndserver/objects/items.py
@@ -1,3 +1,5 @@
+from typing import Tuple, List
+
 from dndserver.handlers import item as hItem
 from dndserver.protos import Item as item
 from dndserver.data import merchant
@@ -44,11 +46,11 @@ class Item:
             new_item.secondaryPropertyArray.append(new_prop)
 
 
-def generate_item(name, type, rarity, inventoryId, slotId, item_count=1):
+def generate_item(name, type, rarity, inventoryId, slotId, item_count=1) -> item.SItem:
     return item_parser(hItem.generate_new_item(name.value, type, rarity, item_count), inventoryId, slotId, item_count)
 
 
-def item_parser(item_values, inventoryId, slotId, item_count):
+def item_parser(item_values, inventoryId, slotId, item_count) -> item.SItem:
     newItem = item.SItem()
     newItem.inventoryId = inventoryId
     newItem.slotId = slotId
@@ -76,7 +78,7 @@ def item_parser(item_values, inventoryId, slotId, item_count):
     return newItem
 
 
-def generate_random_item(merch_id, amount):
+def generate_random_item(merch_id, amount) -> List[Tuple[item.SItem, int]]:
     ret = []
 
     # TODO: Add Merchants when we know what they sell
@@ -123,7 +125,7 @@ def generate_random_item(merch_id, amount):
     return sorted_ret
 
 
-def generate_merch_items(merch_id):
+def generate_merch_items(merch_id) -> List[Tuple[item.SItem, int]]:
     items = merchant.fixed_items[merch_id]
     ret = []
 
@@ -134,24 +136,3 @@ def generate_merch_items(merch_id):
         ret.append((newItem, item_merch[2]))
 
     return ret + generate_random_item(merch_id, len(merchant.buy_mapping[merch_id]) - len(items))
-
-
-def generate_reckless():
-    skills = item.SSkill()
-    skills.index = 1
-    skills.skillId = "DesignDataSkill:Id_Skill_RecklessAttack"
-    return skills
-
-
-def generate_adrenaline():
-    skills = item.SSkill()
-    skills.index = 2
-    skills.skillId = "DesignDataSkill:Id_Skill_AdenalineRush"
-    return skills
-
-
-def generate_two_hander():
-    skills = item.SPerk()
-    skills.index = 1
-    skills.perkId = "DesignDataPerk:Id_Perk_TwoHander"
-    return skills

--- a/dndserver/protocol.py
+++ b/dndserver/protocol.py
@@ -38,7 +38,7 @@ class GameProtocol(Protocol):
         user = User()
         sessions[self.transport] = user
 
-    def connectionLost(self, reason):
+    def connectionLost(self, reason) -> None:
         """Event for when a client disconnects from the server."""
         logger.debug(f"Lost connection to: {self.transport.client[0]}:{self.transport.client[1]}")
 
@@ -133,16 +133,16 @@ class GameProtocol(Protocol):
             res = handlers[handler[0]](self, msg)
             self.reply(msg=res)
 
-    def heartbeat(self):
+    def heartbeat(self) -> None:
         """Send a D&D keepalive packet."""
         self.transport.write(pc.SS2C_ALIVE_RES().SerializeToString())
 
-    def reply(self, msg: bytes):
+    def reply(self, msg: bytes) -> None:
         """Send a D&D packet to the current context transport."""
         header = make_header(msg)
         self.transport.write(header + msg.SerializeToString())
 
-    def send(self, transport, msg: bytes):
+    def send(self, transport, msg: bytes) -> None:
         """Send a D&D packet to a specific transport."""
         header = make_header(msg)
         sessions[transport].write(header + msg.SerializeToString())

--- a/dndserver/protocol.py
+++ b/dndserver/protocol.py
@@ -1,7 +1,10 @@
 import struct
+from typing import Optional
 
 from loguru import logger
 from twisted.internet.protocol import Factory, Protocol
+from twisted.internet.interfaces import IAddress, ITransport
+from twisted.python import failure
 
 from dndserver.handlers import (
     character,
@@ -23,7 +26,7 @@ from dndserver.utils import make_header
 
 
 class GameFactory(Factory):
-    def buildProtocol(self, addr) -> Protocol:
+    def buildProtocol(self, addr: IAddress) -> Optional[Protocol]:
         return GameProtocol()
 
 
@@ -38,7 +41,7 @@ class GameProtocol(Protocol):
         user = User()
         sessions[self.transport] = user
 
-    def connectionLost(self, reason) -> None:
+    def connectionLost(self, reason: failure.Failure) -> None:
         """Event for when a client disconnects from the server."""
         logger.debug(f"Lost connection to: {self.transport.client[0]}:{self.transport.client[1]}")
 
@@ -142,7 +145,7 @@ class GameProtocol(Protocol):
         header = make_header(msg)
         self.transport.write(header + msg.SerializeToString())
 
-    def send(self, transport, msg: bytes) -> None:
+    def send(self, transport: ITransport, msg: bytes) -> None:
         """Send a D&D packet to a specific transport."""
         header = make_header(msg)
         sessions[transport].write(header + msg.SerializeToString())

--- a/dndserver/server.py
+++ b/dndserver/server.py
@@ -11,7 +11,7 @@ from dndserver.protocol import GameFactory
 from dndserver.console import console
 
 
-async def main():
+async def main() -> None:
     """Entrypoint where the server first initializes"""
     signal.signal(signal.SIGINT, signal.default_int_handler)
     # Stop the server from executing if the database is missing.

--- a/dndserver/utils.py
+++ b/dndserver/utils.py
@@ -1,17 +1,22 @@
+from typing import Optional, Tuple
 import struct
+from twisted.internet.interfaces import ITransport
 
+from dndserver.objects.user import User
 from dndserver.persistent import sessions
 from dndserver.protos import PacketCommand as pc
 
 
-def make_header(msg: bytes):
+def make_header(msg: bytes) -> bytes:
     """Create a D&D packet header."""
     # header: <packet length: short> 00 00 <packet id: short> 00 00
     packet_type = type(msg).__name__.replace("SS2C", "S2C").replace("SC2S", "C2S")
     return struct.pack("<HxxHxx", len(msg.SerializeToString()) + 8, pc.PacketCommand.Value(packet_type))
 
 
-def get_user(username: str = None, nickname: str = None, account_id: int = None):
+def get_user(
+    username: str = None, nickname: str = None, account_id: int = None
+) -> Tuple[Optional[ITransport], Optional[User]]:
     """Return a user object based on the account username, character nickname or account ID provided."""
     if not any([username, nickname, account_id]):
         raise Exception("Did not pass username, nickname, or account_id, need at least one")
@@ -33,7 +38,9 @@ def get_user(username: str = None, nickname: str = None, account_id: int = None)
     return None, None
 
 
-def get_party(username: str = None, nickname: str = None, account_id: int = None):
+def get_party(
+    username: str = None, nickname: str = None, account_id: int = None
+) -> Tuple[Optional[ITransport], Optional[User]]:
     """Return a party object based on the account username, character nickname or account ID provided."""
     if not username and not nickname and not account_id:
         raise Exception("Did not pass username, nickname, or account_id, need at least one")


### PR DESCRIPTION
## Briefly describe what changes this PR introduces
Added python type hinting to all parameters (except `console.py` and all the `ctx` and `self` parameters) and returns. (It also formatted every file on save and I removed 3 unused item generator functions)

## Link to all issues that this PR solves
N/A.

## Relevant pictures/videos of the PR (optional)
N/A.

## Checklist
- [ ] This change introduces new dependencies and I have included updated `pyproject.toml` and `poetry.lock` files. 
- [ ] This change requires database migrations and I have included an alembic migration.